### PR TITLE
Added validation for the ajax requests

### DIFF
--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Translator;
@@ -200,7 +199,7 @@ class WebUIController extends Controller
 
     /**
      * @param Request $request
-     * @param array $validationGroups
+     * @param array   $validationGroups
      *
      * @return GuiMessageRepresentation
      */

--- a/Exception/MessageValidationException.php
+++ b/Exception/MessageValidationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Translation\Bundle\Exception;
+
+use Translation\Common\Exception;
+
+class MessageValidationException extends \Exception implements Exception
+{
+    public static function create($message = 'Validation of the translation message failed.')
+    {
+        return new self($message);
+    }
+}

--- a/Exception/MessageValidationException.php
+++ b/Exception/MessageValidationException.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Translation\Bundle\Exception;
 
 use Translation\Common\Exception;

--- a/Model/GuiMessageRepresentation.php
+++ b/Model/GuiMessageRepresentation.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Translation\Bundle\Model;
 
 use Symfony\Component\Validator\Constraints as Assert;

--- a/Model/GuiMessageRepresentation.php
+++ b/Model/GuiMessageRepresentation.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Translation\Bundle\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class GuiMessageRepresentation
+{
+    /**
+     * @var string
+     * @Assert\NotBlank(groups={"Create", "Edit", "Delete"})
+     */
+    private $key;
+
+    /**
+     * @var string
+     * @Assert\NotBlank(groups={"Create", "Edit"})
+     */
+    private $message;
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return GuiMessageRepresentation
+     */
+    public function setKey($key)
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return GuiMessageRepresentation
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Fixed issue #6 

I did not use the serializer component for two reasons. 
1) I try to keep the dependencies to a minimum. 
2) It would require us to add normalizers to the serializer. Configuring the serializer service would be more lines than the current use case. 

This PR is using proper validation though. 