### PR TITLE
Clear the translations cache after editing with Edit In Place

### DIFF
--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -44,7 +44,29 @@ class EditInPlaceController extends Controller
             $storage->update($message->convertToMessage($locale));
         }
 
+        $this->rebuildTranslations();
+
         return new Response();
+    }
+
+    /**
+     * Remove the Symfony translation cache and warm it up again.
+     */
+    private function rebuildTranslations()
+    {
+        $cacheDir = $this->getParameter('kernel.cache_dir');
+        $translationDir = sprintf("%s/translations", $cacheDir);
+
+        $filesystem = $this->get('filesystem');
+        if (!is_writable($translationDir)) {
+            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $translationDir));
+        }
+
+        if ($filesystem->exists($translationDir)) {
+            $filesystem->remove($translationDir);
+        }
+
+        $this->get('translator')->warmUp();
     }
 
     /**


### PR DESCRIPTION
This is a proposal for cache clearing after translation editing. As the Edit In Place functionality is supposed to be used "live", it was looking "broken" because even if a translation is edited correctly, Symfony still display the old messages until the cache is cleared.

I can't think of any better solution but I do not like this very much, editing the cache directory seems like a hack... :confused: 

II tried another approach: doing a `touch()` on the translation files and calling the warmer, but Symfony Cache implementation for translations don't have any resourceCheckers so it can't work. We have to remove the file for them to be rewritten.

About the `name('*.'.$locale.'.*')` pattern, I checked and it's compatible with Symfony 2.7 and more.

Ref #63 

