### PR TITLE
fixed attribution replacement

### DIFF
--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -74,7 +74,7 @@ HTML;
             $content = $event->getResponse()->getContent();
 
             // Clean the content for malformed tags in attributes or encoded tags
-            $content = preg_replace("@=\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi", "=\"🚫 Can't be translated here. 🚫\"", $content);
+            $content = preg_replace("@=\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi", "=\"$1🚫 Can't be translated here. 🚫\"", $content);
             $content = preg_replace('@&lt;x-trans.+data-key=&quot;([^&]+)&quot;.+&lt;\\/x-trans&gt;@mi', '🚫 $1 🚫', $content);
 
             $html = sprintf(

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -74,7 +74,7 @@ HTML;
             $content = $event->getResponse()->getContent();
 
             // Clean the content for malformed tags in attributes or encoded tags
-            $content = preg_replace("@=\\s*[\"']\\s*(<x-trans.+<\\/x-trans>)\\s*[\"']@mi", "=\"🚫 Can't be translated here. 🚫\"", $content);
+            $content = preg_replace("@=\\s*[\"']\\s*(<x-trans.+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi", "=\"🚫 Can't be translated here. 🚫\"", $content);
             $content = preg_replace('@&lt;x-trans.+data-key=&quot;([^&]+)&quot;.+&lt;\\/x-trans&gt;@mi', '🚫 $1 🚫', $content);
 
             $html = sprintf(

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -74,7 +74,7 @@ HTML;
             $content = $event->getResponse()->getContent();
 
             // Clean the content for malformed tags in attributes or encoded tags
-            $content = preg_replace("@=\\s*[\"']\\s*(<x-trans.+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi", "=\"🚫 Can't be translated here. 🚫\"", $content);
+            $content = preg_replace("@=\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi", "=\"🚫 Can't be translated here. 🚫\"", $content);
             $content = preg_replace('@&lt;x-trans.+data-key=&quot;([^&]+)&quot;.+&lt;\\/x-trans&gt;@mi', '🚫 $1 🚫', $content);
 
             $html = sprintf(

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -52,7 +52,7 @@ class EditInPlaceTest extends BaseTestCase
 
         // Check attribute with prefix (href="mailto:...")
         $emailTag = $dom->getElementById('email');
-        self::assertEquals('🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
+        self::assertEquals('mailto:🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
         self::assertEquals('localized.email', $emailTag->textContent);
 
         // Check attribute

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -52,7 +52,7 @@ class EditInPlaceTest extends BaseTestCase
 
         // Check attribute with prefix (href="mailto:...")
         $emailTag = $dom->getElementById('email');
-        self::assertEquals('mailto:' . '🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
+        self::assertEquals('mailto:'.'🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
         self::assertEquals('localized.email', $emailTag->textContent);
 
         // Check attribute

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -46,8 +46,17 @@ class EditInPlaceTest extends BaseTestCase
         @$dom->loadHTML($response->getContent());
         $xpath = new \DomXpath($dom);
 
+        // Check number of x-trans tags
         $xtrans = $xpath->query('//x-trans');
+        self::assertEquals(6, $xtrans->length);
 
-        self::assertEquals(5, $xtrans->length);
+        // Check attribute with prefix (href="mailto:...")
+        $emailTag = $dom->getElementById('email');
+        self::assertEquals('🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
+        self::assertEquals('localized.email', $emailTag->textContent);
+
+        // Check attribute
+        $attributeDiv = $dom->getElementById('attribute-div');
+        self::assertEquals('🚫 Can\'t be translated here. 🚫', $attributeDiv->getAttribute('data-value'));
     }
 }

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -42,7 +42,7 @@ class EditInPlaceTest extends BaseTestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertContains('<!-- TranslationBundle -->', $response->getContent());
 
-        $dom = new \DOMDocument();
+        $dom = new \DOMDocument('1.0', 'utf-8');
         @$dom->loadHTML($response->getContent());
         $xpath = new \DomXpath($dom);
 
@@ -52,7 +52,7 @@ class EditInPlaceTest extends BaseTestCase
 
         // Check attribute with prefix (href="mailto:...")
         $emailTag = $dom->getElementById('email');
-        self::assertEquals('mailto:🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
+        self::assertEquals('mailto:' . '🚫 Can\'t be translated here. 🚫', $emailTag->getAttribute('href'));
         self::assertEquals('localized.email', $emailTag->textContent);
 
         // Check attribute

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -43,7 +43,7 @@ class EditInPlaceTest extends BaseTestCase
         self::assertContains('<!-- TranslationBundle -->', $response->getContent());
 
         $dom = new \DOMDocument('1.0', 'utf-8');
-        @$dom->loadHTML($response->getContent());
+        @$dom->loadHTML(mb_convert_encoding($response->getContent(), 'HTML-ENTITIES', 'UTF-8'));
         $xpath = new \DomXpath($dom);
 
         // Check number of x-trans tags

--- a/Tests/Functional/app/Resources/views/translated.html.twig
+++ b/Tests/Functional/app/Resources/views/translated.html.twig
@@ -6,8 +6,11 @@
 </head>
 <body>
     <h1>{{ 'translated.heading'|transchoice(12) }}</h1>
-    <p>{{ 'translated.paragraph0'|trans }}</p>
-    <p>{% trans %}translated.paragraph1{% endtrans %}</p>
-    <p>{% transchoice 21 %}translated.paragraph2{% endtranschoice %}</p>
+    <p>{{ 'translated.paragraph0'|trans }}</p><p>{% trans %}translated.paragraph1{% endtrans %}</p><!-- two translation in same html line -->
+    <p>
+        {% transchoice 21 %}translated.paragraph2{% endtranschoice %}
+        <a id="email" href="mailto:{{ 'localized.email'|trans }}">{{ 'localized.email'|trans }}</a><!-- translation inside attribute with additional content -->
+    </p>
+    <div id="attribute-div" data-value="{{ 'translated.attribute'|trans }}"></div> <!-- translation inside html attribute -->
 </body>
 </html>


### PR DESCRIPTION
- fixes issue where everything was removed between two translations of html attribute contents on the same line
- fixed issue when translation used in special link with additional content in href attribute: `<a href="email:*localizedEmail*">`