### PR TITLE
Web UI translate input field set as email

### DIFF
--- a/Resources/views/WebUI/show.html.twig
+++ b/Resources/views/WebUI/show.html.twig
@@ -49,7 +49,7 @@
                 </div>
                 <div class="form-group">
                     <label for="create-message">Translation</label>
-                    <input type="email" class="form-control" id="create-message" placeholder="Lorem Ipsum">
+                    <input type="text" class="form-control" id="create-message" placeholder="Lorem Ipsum">
                 </div>
                 <button type="submit" class="btn btn-primary">Create</button>
                 <div class="ajax-result"></div>


### PR DESCRIPTION
Just replaced "email" by "text" in WebUI show view.