### PR TITLE
Let profiler textarea use full available width

### DIFF
--- a/Resources/views/SymfonyProfiler/edit.html.twig
+++ b/Resources/views/SymfonyProfiler/edit.html.twig
@@ -1,3 +1,3 @@
-<textarea id="edit_{{ key }}">{{ message.translation }}</textarea>
+<textarea style="width: 100%" id="edit_{{ key }}">{{ message.translation }}</textarea>
 <input type="button" value="Save" onclick='saveEditForm("{{ key }}", document.getElementById("edit_{{ key }}").value)'>
 <input type="button" value="Cancel" onclick='cancelEditForm("{{ key }}", "{{ message.translation }}")'>


### PR DESCRIPTION
Right now the profiler textarea is too small, made it use the full width.