### PR TITLE
Add configuration option to not show "untranslatable"

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -180,6 +180,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('config_name')->defaultValue('default')->end()
                     ->scalarNode('activator')->cannotBeEmpty()->defaultValue('php_translation.edit_in_place.activator')->end()
+                    ->scalarNode('show_untranslatable')->defaultTrue()->end()
                 ->end()
             ->end()
         ->end();

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -169,6 +169,7 @@ class TranslationExtension extends Extension
         $def = $container->getDefinition('php_translation.edit_in_place.response_listener');
         $def->replaceArgument(0, $activatorRef);
         $def->replaceArgument(3, $name);
+        $def->replaceArgument(4, $config['edit_in_place']['show_untranslatable']);
 
         $def = $container->getDefinition('php_translator.edit_in_place.xtrans_html_translator');
         $def->replaceArgument(1, $activatorRef);

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -89,7 +89,7 @@ HTML;
         $replacement = "=\"$1🚫 Can't be translated here. 🚫\"";
         $pattern = "@=\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+data-value=\"([^&\"]+)\".+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi";
         if (!$this->showUntranslatable) {
-            $replacement = "=\"$3\"";
+            $replacement = '="$3"';
         }
         $content = preg_replace($pattern, $replacement, $content);
 
@@ -97,7 +97,7 @@ HTML;
         $pattern = '@&lt;x-trans.+data-key=&quot;([^&]+)&quot;.+data-value=&quot;([^&]+)&quot;.+&lt;\\/x-trans&gt;@mi';
         $replacement = '🚫 $1 🚫';
         if (!$this->showUntranslatable) {
-            $replacement = '="$3"';
+            $replacement = '$2';
         }
         $content = preg_replace($pattern, $replacement, $content);
 

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -65,7 +65,7 @@ HTML;
      */
     private $showUntranslatable;
 
-    public function __construct(ActivatorInterface $activator, Router $router, Packages $packages, $configName = 'default', $showUntranslatable)
+    public function __construct(ActivatorInterface $activator, Router $router, Packages $packages, $configName = 'default', $showUntranslatable = true)
     {
         $this->activator = $activator;
         $this->router = $router;

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -65,7 +65,7 @@ HTML;
      */
     private $showUntranslatable;
 
-    public function __construct(ActivatorInterface $activator, Router $router, Packages $packages, $configName = 'default', $showUntranslatable = true)
+    public function __construct(ActivatorInterface $activator, Router $router, Packages $packages, $configName = 'default', $showUntranslatable)
     {
         $this->activator = $activator;
         $this->router = $router;

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -97,7 +97,7 @@ HTML;
         $pattern = '@&lt;x-trans.+data-key=&quot;([^&]+)&quot;.+data-value=&quot;([^&]+)&quot;.+&lt;\\/x-trans&gt;@mi';
         $replacement = '🚫 $1 🚫';
         if (!$this->showUntranslatable) {
-            $replacement = "$2";
+            $replacement = '="$3"';
         }
         $content = preg_replace($pattern, $replacement, $content);
 

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -85,10 +85,10 @@ HTML;
         $content = $event->getResponse()->getContent();
 
         // Clean the content for malformed tags in attributes or encoded tags
-        $replacement = "=\"$1🚫 Can't be translated here. 🚫\"";
-        $pattern = "@=\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+data-value=\"([^&\"]+)\".+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi";
+        $replacement = "\"$1🚫 Can't be translated here. 🚫\"";
+        $pattern = "@\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+data-value=\"([^&\"]+)\".+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi";
         if (!$this->showUntranslatable) {
-            $replacement = '="$3"';
+            $replacement = '"$3"';
         }
         $content = preg_replace($pattern, $replacement, $content);
 

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -65,7 +65,6 @@ HTML;
      */
     private $showUntranslatable;
 
-
     public function __construct(ActivatorInterface $activator, Router $router, Packages $packages, $configName = 'default', $showUntranslatable)
     {
         $this->activator = $activator;

--- a/Resources/config/edit_in_place.yml
+++ b/Resources/config/edit_in_place.yml
@@ -8,6 +8,7 @@ services:
       - '@router'
       - '@assets.packages'
       - ~
+      - ~
 
   php_translation.edit_in_place.activator:
     class: Translation\Bundle\EditInPlace\Activator

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -58,20 +58,28 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
+        $original = $this->translator->trans($id, $parameters, $domain, $locale);
         if (!$this->activator->checkRequest($this->requestStack->getMasterRequest())) {
-            return $this->translator->trans($id, $parameters, $domain, $locale);
+            return $original;
         }
+
+        $plain = $this->translator->trans($id, [], $domain, $locale);
 
         if (null === $domain) {
             $domain = 'messages';
         }
+        if (null === $locale) {
+            $locale = $this->translator->getLocale();
+        }
 
-        $original = $this->translator->trans($id, $parameters, $domain, $locale);
-
-        // todo add data-value="" or data-type with real content, add parameters, domain...
-        return sprintf('<x-trans data-key="%s|%s">%s</x-trans>',
+        // Render all data in the translation tag required to allow in-line translation
+        return sprintf('<x-trans data-key="%s|%s" data-value="%s" data-plain="%s" data-domain="%s" data-locale="%s">%s</x-trans>',
             $domain,
             $id,
+            $original,
+            $plain,
+            $domain,
+            $locale,
             $original
         );
     }


### PR DESCRIPTION
Introduce a new configuration option below `edit_in_place` to not show the "untranslatable" label, but show the original content instead. Translators then still can do the translation via the profiler or webUI integration. See #66 

```yml
translation:
    # ...
    edit_in_place:
        # ...
        show_untranslatable: false # default = true
```

This PR also is a preparation for #87 in order to not replace the parameters via "edit in place", as the `<x-trans>` tags now also include the original and plain translation.

/cc @damienalexandre 