### PR TITLE
Make sure we fail with an exception if SfTranslation is not enabled.

### DIFF
--- a/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
+++ b/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * Make sure we have all the dependencies for Symfony Profiler
+ * Make sure we have all the dependencies for Symfony Profiler.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */

--- a/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
+++ b/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Make sure we have all the dependencies for Symfony Profiler
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class SymfonyProfilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        /* @var Definition $def */
+        if (!$container->hasDefinition('php_translation.data_collector')) {
+            return;
+        }
+
+        if (!$container->hasDefinition('translator.data_collector')) {
+            throw new \LogicException('[PHP-Translation] To integrate with the Symfony profiler you first need to enable it. Please set framework.translator.enabled: true');
+        }
+    }
+}

--- a/Resources/config/symfony_profiler.yml
+++ b/Resources/config/symfony_profiler.yml
@@ -1,6 +1,6 @@
 services:
   php_translation.data_collector:
     class: Symfony\Component\Translation\DataCollector\TranslationDataCollector
-    arguments: [ '@?translator.data_collector' ]
+    arguments: [ '@translator.data_collector' ]
     tags:
       - { name: 'data_collector', template: "@Translation/SymfonyProfiler/translation.html.twig", id: "translation", priority: 200 }

--- a/TranslationBundle.php
+++ b/TranslationBundle.php
@@ -17,6 +17,7 @@ use Translation\Bundle\DependencyInjection\CompilerPass\EditInPlacePass;
 use Translation\Bundle\DependencyInjection\CompilerPass\ExternalTranslatorPass;
 use Translation\Bundle\DependencyInjection\CompilerPass\ExtractorPass;
 use Translation\Bundle\DependencyInjection\CompilerPass\StoragePass;
+use Translation\Bundle\DependencyInjection\CompilerPass\SymfonyProfilerPass;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -25,6 +26,7 @@ class TranslationBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new SymfonyProfilerPass());
         $container->addCompilerPass(new ExternalTranslatorPass());
         $container->addCompilerPass(new ExtractorPass());
         $container->addCompilerPass(new StoragePass());


### PR DESCRIPTION
If you are trying to use the Symfony Profiler and the SymfonyTranslation is not enabled, we should fail with an exception. 