### PR TITLE
Fix type of data returned by translation data collector since sf 3.3

### DIFF
--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Translation\Bundle\Model\SfProfilerMessage;
 use Translation\Bundle\Service\StorageService;
 use Translation\Common\Model\Message;
@@ -154,6 +155,11 @@ class SymfonyProfilerController extends Controller
         }
 
         $messages = $dataCollector->getMessages();
+
+        if ($messages instanceof Data) {
+            $messages = $messages->getValue(true);
+        }
+
         if (!isset($messages[$messageId])) {
             throw $this->createNotFoundException(sprintf('No message with key "%s" was found.', $messageId));
         }
@@ -185,7 +191,13 @@ class SymfonyProfilerController extends Controller
 
         $profile = $profiler->loadProfile($token);
         $dataCollector = $profile->getCollector('translation');
-        $toSave = array_intersect_key($dataCollector->getMessages(), array_flip($selected));
+        $messages = $dataCollector->getMessages();
+
+        if ($messages instanceof Data) {
+            $messages = $messages->getValue(true);
+        }
+
+        $toSave = array_intersect_key($messages, array_flip($selected));
 
         $messages = [];
         foreach ($toSave as $data) {

--- a/Resources/config/routing_symfony_profiler.yml
+++ b/Resources/config/routing_symfony_profiler.yml
@@ -15,6 +15,6 @@ php_translation_profiler_translation_sync_all:
   defaults:  { _controller: TranslationBundle:SymfonyProfiler:syncAll }
 
 php_translation_profiler_translation_create_assets:
-  path: /{token}/translation/sync_all
+  path: /{token}/translation/create_assets
   methods: ["POST"]
   defaults:  { _controller: TranslationBundle:SymfonyProfiler:createAssets }


### PR DESCRIPTION
Ref #95 

Since this commit (https://github.com/symfony/translation/commit/79fe2b4039e0bac60fb28adaa9bc1f61730b8601#diff-d6cd38dc7a79e5153bf5a542aae85c4bR48) getMessages returns a Data object and not an array anymore.

---

*Quick-fix*: I've updated routing_symfony_profiler.yml because `createAssets` seems to me as never having been followed ^^' (ping @damienalexandre)
