### PR TITLE
Add Meta Informations to the common Message object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
 
 env:
   global:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 # Change Log
 
-The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
 ## UNRELEASED
+
+### Changed
+
+- Add meta informations from the profiler to `Translation\Common\Model\Message`
 
 ## 0.3.2
 
@@ -58,19 +62,19 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - `Translation\Bundle\Service\CatalogueFetcher` moved to `Translation\Bundle\Catalogue\CatalogueFetcher`
-- Made most (if not all) classes final. 
+- Made most (if not all) classes final.
 - `CatalogueFetcher` requires a `Configuration` object.
 
 ### Removed
 
 - Dead code in the `SymfonyProfilerController`
-- `FileStorage` was moved to `php-translation/symfony-storage` 
+- `FileStorage` was moved to `php-translation/symfony-storage`
 
 ### Fixed
 
-- The bundle works without any configuration. 
+- The bundle works without any configuration.
 - You may have an config named "default".
 
 ## 0.1.0
 
-First release. 
+First release.

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -126,7 +126,8 @@ final class SfProfilerMessage
          $meta = [];
 
          if (!empty($this->getParameters())) {
-             $meta['parameters'] = $this->getParameters();
+             // Reduce to only get one value of each parameter, not all the usages.
+             $meta['parameters'] = array_reduce($this->getParameters(), 'array_merge', array());
          }
 
          if (!empty($this->getCount())) {

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -127,7 +127,7 @@ final class SfProfilerMessage
 
          if (!empty($this->getParameters())) {
              // Reduce to only get one value of each parameter, not all the usages.
-             $meta['parameters'] = array_reduce($this->getParameters(), 'array_merge', array());
+             $meta['parameters'] = array_reduce($this->getParameters(), 'array_merge', []);
          }
 
          if (!empty($this->getCount())) {

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -116,20 +116,35 @@ final class SfProfilerMessage
         return $message;
     }
 
-    /**
-     * Convert to a Common\Message.
-     *
-     * @return Message
-     */
-    public function convertToMessage()
-    {
-        return new Message(
-            $this->key,
-            $this->domain,
-            $this->locale,
-            $this->translation
-        );
-    }
+     /**
+      * Convert to a Common\Message.
+      *
+      * @return Message
+      */
+     public function convertToMessage()
+     {
+         $meta = [];
+
+         if (!empty($this->getParameters())) {
+             $meta['parameters'] = $this->getParameters();
+         }
+
+         if (!empty($this->getCount())) {
+             $meta['count'] = $this->getCount();
+         }
+
+         if (!empty($this->getTransChoiceNumber())) {
+             $meta['transChoiceNumber'] = $this->getTransChoiceNumber();
+         }
+
+         return new Message(
+             $this->key,
+             $this->domain,
+             $this->locale,
+             $this->translation,
+             $meta
+         );
+     }
 
     /**
      * @return int


### PR DESCRIPTION
See https://github.com/php-translation/loco-adapter/pull/7 and https://github.com/FriendsOfApi/localise.biz/pull/16.

This PR adds Meta informations from the Data Collector Message to the Common Message object. This allow the Loco-Adapter to use this Meta information in order to add the parameters as notes on newly created assets.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/225704/26036076/55b4b63c-38d7-11e7-8da2-39764490e2f6.png)