### PR TITLE
Make sure we do not bind to specific twig version before the TwigVisi…

### DIFF
--- a/Resources/config/extractors.yml
+++ b/Resources/config/extractors.yml
@@ -53,7 +53,7 @@ services:
 
   # Twig Visitors:
   php_translation.extractor.twig.visitor.twig:
-    class: Translation\Extractor\Visitor\Twig\Twig2Visitor
+    class: Translation\Bundle\Twig\DummyTwigVisitor
     factory: [Translation\Extractor\Visitor\Twig\TwigVisitor, create]
     tags:
       - { name: 'php_translation.visitor', type: 'twig' }

--- a/Twig/DummyTwigVisitor.php
+++ b/Twig/DummyTwigVisitor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Translation\Bundle\Twig;
 
 /**
@@ -10,5 +19,4 @@ namespace Translation\Bundle\Twig;
  */
 class DummyTwigVisitor
 {
-
 }

--- a/Twig/DummyTwigVisitor.php
+++ b/Twig/DummyTwigVisitor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Translation\Bundle\Twig;
+
+/**
+ * This dummy extractor is used to be compatible with both Twig1 and Twig2. It is only used in dependency injection
+ * container.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DummyTwigVisitor
+{
+
+}


### PR DESCRIPTION
…torFactory has been executed

To fix the error on SF twig1: 

>  Fatal error: Declaration of Translation\Extractor\Visitor\Twig\Twig2Visitor::enterNode(Twig_Node $node, Twig_Environment $env) must be compatible with Twig_NodeVisitorInterface::enterNode(Twig_NodeInterface $node, Twig_Environment $env) in local/path/vendor/php-translation/extractor/src/Visitor/Twig/Twig2Visitor.php on line 20  