### PR TITLE
Do not "override" Twig trans filters as being html safe

### DIFF
--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -25,8 +25,8 @@ class TranslationExtension extends \Symfony\Bridge\Twig\Extension\TranslationExt
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('trans', [$this, 'trans'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('transchoice', [$this, 'transchoice'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFilter('trans', [$this, 'trans']),
+            new \Twig_SimpleFilter('transchoice', [$this, 'transchoice']),
         ];
     }
 


### PR DESCRIPTION
as that conflicts with the behavior in environments where `debug = false`.

Fixes #100 