### PR TITLE
Switch activator comparison result

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 0.3.5
+
+### Fixed
+
+- Fix incorrect EditInPlace activation on Twig `is_safe` comparison
+
 ## 0.3.4
 
 ### Fixed

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -81,7 +81,7 @@ class EditInPlaceTest extends BaseTestCase
         $attributeDiv = $dom->getElementById('attribute-div');
         self::assertEquals('translated.attribute', $attributeDiv->getAttribute('data-value'));
     }
-    
+
     public function testDeactivatedTest()
     {
         $this->bootKernel();

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class EditInPlaceTest extends BaseTestCase
 {
-
     public function testActivatedTest()
     {
         $this->bootKernel();

--- a/Tests/Functional/EditInPlaceTest.php
+++ b/Tests/Functional/EditInPlaceTest.php
@@ -18,15 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class EditInPlaceTest extends BaseTestCase
 {
-    public function testDeactivatedTest()
-    {
-        $this->bootKernel();
-        $request = Request::create('/foobar');
-        $response = $this->kernel->handle($request);
-
-        self::assertSame(200, $response->getStatusCode());
-        self::assertNotContains('x-trans', $response->getContent());
-    }
 
     public function testActivatedTest()
     {
@@ -89,5 +80,15 @@ class EditInPlaceTest extends BaseTestCase
         // Check attribute
         $attributeDiv = $dom->getElementById('attribute-div');
         self::assertEquals('translated.attribute', $attributeDiv->getAttribute('data-value'));
+    }
+    
+    public function testDeactivatedTest()
+    {
+        $this->bootKernel();
+        $request = Request::create('/foobar');
+        $response = $this->kernel->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotContains('x-trans', $response->getContent());
     }
 }

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -50,7 +50,7 @@ class TranslationExtension extends \Symfony\Bridge\Twig\Extension\TranslationExt
      */
     public function isSafe($node)
     {
-        return $this->activator->checkRequest($this->requestStack->getMasterRequest()) ? [] : ['html'];
+        return $this->activator->checkRequest($this->requestStack->getMasterRequest()) ? ['html'] : [];
     }
 
     /**


### PR DESCRIPTION
... as now output is marked as safe when `EditInPlace` is inactive. Should be the other way around.