### PR TITLE
[EditInPlace] Use `plain` for translation

### DIFF
--- a/Resources/public/js/editInPlace.js
+++ b/Resources/public/js/editInPlace.js
@@ -59,6 +59,14 @@ var TranslationBundleEditInPlace = function(saveUrl) {
         // false = classic HTML block
         return domRegion.dataset.key.split('.').pop() !== 'html';
     });
+    
+    // Always use `plain` value without parsed parameters
+    editor.addEventListener('start', function (ev) {
+        var elements = Array.prototype.slice.call(document.getElementsByTagName('x-trans'));
+        elements.forEach(function(item, index) {
+            item.innerHTML = item.dataset.plain;
+        });
+    });
 
     // Treat x-trans tags as Text
     ContentEdit.TagNames.get().register(ContentEdit.Text, 'x-trans');


### PR DESCRIPTION
By adding an event listener that replaces all `innerHTML` with the `plain` data attribute we can be sure that the right value gets edited by `ContentTools`.

You also would like to restore it on `stop`, but somehow after that event the `innerHTML` gets overwritten again by ContentTools. See https://github.com/GetmeUK/ContentTools/issues/391#issuecomment-309019583 about that.

Fixes #87 