### PR TITLE
Do not throw exception when SF Translation collector is not found. 

### DIFF
--- a/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
+++ b/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
@@ -30,7 +30,8 @@ class SymfonyProfilerPass implements CompilerPassInterface
         }
 
         if (!$container->hasDefinition('translator.data_collector')) {
-            throw new \LogicException('[PHP-Translation] To integrate with the Symfony profiler you first need to enable it. Please set framework.translator.enabled: true');
+            // No Symfony translation data collector was found. We cannot use our collection without it.
+            $container->removeDefinition('php_translation.data_collector');
         }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
         $this->addEditInPlaceNode($root);
         $this->addWebUINode($root);
 
+        $debug = $this->container->getParameter('kernel.debug');
         $root
             ->children()
                 ->arrayNode('locales')
@@ -48,7 +49,22 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_locale')->info('Your default language or fallback locale. Default will be kernel.default_locale')->end()
                 ->arrayNode('symfony_profiler')
-                    ->canBeEnabled()
+                    ->addDefaultsIfNotSet()
+                    ->treatFalseLike(['enabled' => false])
+                    ->treatTrueLike(['enabled' => true])
+                    ->treatNullLike(['enabled' => $debug])
+                    ->info('Extend the debug profiler with information about requests.')
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->info('Turn the symfony profiler integration on or off. Defaults to kernel debug mode.')
+                            ->defaultValue($debug)
+                        ->end()
+                        ->scalarNode('formatter')->defaultNull()->end()
+                        ->integerNode('captured_body_length')
+                            ->defaultValue(0)
+                            ->info('Limit long HTTP message bodies to x characters. If set to 0 we do not read the message body. Only available with the default formatter (FullHttpMessageFormatter).')
+                        ->end()
+                    ->end()
                     ->children()
                         ->booleanNode('allow_edit')->defaultTrue()->end()
                     ->end()

--- a/Tests/Unit/DependencyInjection/TranslationExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/TranslationExtensionTest.php
@@ -24,6 +24,7 @@ class TranslationExtensionTest extends AbstractExtensionTestCase
     {
         $this->setParameter('kernel.default_locale', 'ar');
         $this->setParameter('kernel.root_dir', __DIR__);
+        $this->setParameter('kernel.debug', true);
 
         return [
             new TranslationExtension(),

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "0.4-dev"


### PR DESCRIPTION
Symfony profiler integration default value changed to "same as debug mode".

We do not longer throw exception when Symfony Translation collector was not found.

This will fix #107 

Ping @aradoje 