### PR TITLE
Add a --cache option on translation:download to clear the cache

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,27 +2,33 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## Unreleased
+
+## Added
+
+- New `--cache` option on the `translation:download` allowing to clear the cache automatically if the downloaded translations have changed.
+
 ## 0.4.0
 
 Major improvements on this version. Be aware that the default format to store translation has changed to XLIFF 2.0. If you
-run the extract command you will automatically get updated files. 
+run the extract command you will automatically get updated files.
 
 ### Added
 
 - More extractors from `php-translation/extractor`
-- Show status after extract command 
+- Show status after extract command
 - Added status command
 - Support for PHPUnit6
 - Support for `php-translation/symfony-storage` 0.3.0
 - Using dumper and loader from `php-translation/extractor`
-- `CatalogeCounter` to show statistics about a catalogue. 
-- Lots of more tests. Test coverage increased from 27% to 69%.
+- `CatalogueCounter` to show statistics about a catalogue
+- Lots of more tests. Test coverage increased from 27% to 69%
 
 ### Changed
 
 - `Importer` returns an `ImportResult` value object
 - Improved internal management of metadata. Introduced a new `Metadata` model
-- Renamed `MetadataAwareMerged` to `ReplaceOperation`, read the class doc for the updated syntax. 
+- Renamed `MetadataAwareMerged` to `ReplaceOperation`, read the class doc for the updated syntax
 
 ### Fixed
 
@@ -31,7 +37,7 @@ run the extract command you will automatically get updated files.
 ### Removed
 
 - Removed `WebUIMessage` and `EditInPlaceMessage`. Use `Message` from `php-translation/common` instead
-- Removed metadata related functions from `CatalogueManager` 
+- Removed metadata related functions from `CatalogueManager`
 
 ### Changed
 
@@ -55,7 +61,7 @@ run the extract command you will automatically get updated files.
 
 ### Fixed
 
-- When using EditInPlace, we only mark twig filters (`trans` & `transchoice`) as "safe" when EditInPlace in active. 
+- When using EditInPlace, we only mark twig filters (`trans` & `transchoice`) as "safe" when EditInPlace in active.
 
 ## 0.3.3
 

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -67,7 +67,7 @@ class DownloadCommand extends ContainerAwareCommand
         }
 
         $finder = new Finder();
-        $finder->files()->in($directory);
+        $finder->files()->in($directory)->notName('/~$/')->sortByName();
 
         $hash = hash_init('md5');
         foreach ($finder as $file) {

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -62,6 +62,10 @@ class DownloadCommand extends ContainerAwareCommand
 
     private function hashDirectory($directory)
     {
+        if (!is_dir($directory)) {
+            return false;
+        }
+
         $finder = new Finder();
         $finder->files()->in($directory);
 

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -13,9 +13,11 @@ namespace Translation\Bundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Translation\Bundle\Service\StorageService;
+use Translation\Bundle\Model\Configuration;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -27,15 +29,57 @@ class DownloadCommand extends ContainerAwareCommand
         $this
             ->setName('translation:download')
             ->setDescription('Replace local messages with messages from remote')
-            ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default');
+            ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
+            ->addOption('cache', null, InputOption::VALUE_NONE, 'Clear the cache if the translations have changed')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getContainer();
         $configName = $input->getArgument('configuration');
+
         /** @var StorageService $storage */
         $storage = $container->get('php_translation.storage.'.$configName);
-        $storage->download();
+        /** @var Configuration $configuration */
+        $configuration = $this->getContainer()->get('php_translation.configuration.'.$configName);
+
+        if ($input->getOption('cache')) {
+            $translationsDirectory = $configuration->getOutputDir();
+            $md5BeforeDownload = $this->hashDirectory($translationsDirectory);
+            $storage->download();
+            $md5AfterDownload = $this->hashDirectory($translationsDirectory);
+
+            if ($md5BeforeDownload !== $md5AfterDownload) {
+                $command = $this->getApplication()->find('cache:clear');
+                $command->run(new ArrayInput(['--no-warmup' => true]), $output);
+            }
+        } else {
+            $storage->download();
+        }
+    }
+
+    private function hashDirectory($directory)
+    {
+        if (!is_dir($directory)) {
+            return false;
+        }
+
+        $files = [];
+        $dir = dir($directory);
+
+        while (false !== ($file = $dir->read())) {
+            if ($file !== '.' and $file !== '..') {
+                if (is_dir($directory.'/'.$file)) {
+                    $files[] = $this->hashDirectory($directory.'/'.$file);
+                } else {
+                    $files[] = md5_file($directory.'/'.$file);
+                }
+            }
+        }
+
+        $dir->close();
+
+        return md5(implode('', $files));
     }
 }

--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -12,7 +12,6 @@
 namespace Translation\Bundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Translation\Bundle\Exception\MessageValidationException;

--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -45,43 +45,10 @@ class EditInPlaceController extends Controller
             $storage->update($message);
         }
 
-        $this->rebuildTranslations($locale);
+        $cacheClearer = $this->get('php_translation.cache_clearer');
+        $cacheClearer->clearAndWarmUp($locale);
 
         return new Response();
-    }
-
-    /**
-     * Remove the Symfony translation cache and warm it up again.
-     *
-     * @param $locale
-     */
-    private function rebuildTranslations($locale)
-    {
-        $cacheDir = $this->getParameter('kernel.cache_dir');
-        $translationDir = sprintf('%s/translations', $cacheDir);
-
-        $filesystem = $this->get('filesystem');
-        $finder = new Finder();
-
-        if (!is_dir($translationDir)) {
-            mkdir($translationDir);
-        }
-
-        if (!is_writable($translationDir)) {
-            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $translationDir));
-        }
-
-        // Remove the translations for this locale
-        $files = $finder->files()->name('*.'.$locale.'.*')->in($translationDir);
-        foreach ($files as $file) {
-            $filesystem->remove($file);
-        }
-
-        // Build them again
-        $translator = $this->get('translator');
-        if (method_exists($translator, 'warmUp')) {
-            $translator->warmUp($translationDir);
-        }
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,10 @@ services:
     class: Translation\Bundle\Service\Importer
     arguments: ["@php_translation.extractor"]
 
+  php_translation.cache_clearer:
+    class: Translation\Bundle\Service\CacheClearer
+    arguments: ["%kernel.cache_dir%", "@translator", "@filesystem"]
+
   php_translation.local_file_storage.abstract:
     class: Translation\SymfonyStorage\FileStorage
     abstract: true

--- a/Service/CacheClearer.php
+++ b/Service/CacheClearer.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
- * A service able to read and clear the Symfony Translation cache
+ * A service able to read and clear the Symfony Translation cache.
  *
  * @author Damien A. <dalexandre@jolicode.com>
  */

--- a/Service/CacheClearer.php
+++ b/Service/CacheClearer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Service;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * A service able to read and clear the Symfony Translation cache
+ *
+ * @author Damien A. <dalexandre@jolicode.com>
+ */
+final class CacheClearer
+{
+    /**
+     * @var string
+     */
+    private $kernelCacheDir;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct($kernelCacheDir, TranslatorInterface $translator, Filesystem $filesystem)
+    {
+        $this->kernelCacheDir = $kernelCacheDir;
+        $this->translator = $translator;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Remove the Symfony translation cache and warm it up again.
+     *
+     * @param string|null $locale Optional filter to clear only one locale.
+     */
+    public function clearAndWarmUp($locale = null)
+    {
+        $translationDir = sprintf('%s/translations', $this->kernelCacheDir);
+
+        $finder = new Finder();
+
+        // Make sure the directory exists
+        $this->filesystem->mkdir($translationDir);
+
+        // Remove the translations for this locale
+        $files = $finder->files()->name($locale ? '*.'.$locale.'.*' : '*')->in($translationDir);
+        foreach ($files as $file) {
+            $this->filesystem->remove($file);
+        }
+
+        // Build them again
+        if ($this->translator instanceof WarmableInterface) {
+            $this->translator->warmUp($translationDir);
+        }
+    }
+}


### PR DESCRIPTION
This new feature allow to clear the local Symfony Cache when we detect a change in the downloaded translations.

It's already used today in production and I'm very please with it, so I think it belong here.

The idea is that you can run this command in a crontab, and when a translation is changed on the remote (SaaS translations like Loco), we can clear the Symfony cache if we detect that you have changed the translations => **instant translation update on productions** :tada: 