### PR TITLE
Fix twig paths for Twig 2.x

### DIFF
--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -48,7 +48,7 @@ class SymfonyProfilerController extends Controller
         if ($request->isMethod('GET')) {
             $translation = $storage->syncAndFetchMessage($message->getLocale(), $message->getDomain(), $message->getKey());
 
-            return $this->render('TranslationBundle:SymfonyProfiler:edit.html.twig', [
+            return $this->render('@Translation/SymfonyProfiler/edit.html.twig', [
                 'message' => $translation,
                 'key' => $message->getLocale().$message->getDomain().$message->getKey(),
             ]);

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -70,7 +70,7 @@ class WebUIController extends Controller
             }
         }
 
-        return $this->render('TranslationBundle:WebUI:index.html.twig', [
+        return $this->render('@Translation/WebUI/index.html.twig', [
             'catalogues' => $catalogues,
             'catalogueSize' => $catalogueSize,
             'maxDomainSize' => $maxDomainSize,
@@ -108,7 +108,7 @@ class WebUIController extends Controller
             return strcmp($a->getKey(), $b->getKey());
         });
 
-        return $this->render('TranslationBundle:WebUI:show.html.twig', [
+        return $this->render('@Translation/WebUI/show.html.twig', [
             'messages' => $messages,
             'domains' => $catalogueManager->getDomains(),
             'currentDomain' => $domain,
@@ -159,7 +159,7 @@ class WebUIController extends Controller
             ), $e);
         }
 
-        return $this->render('TranslationBundle:WebUI:create.html.twig', [
+        return $this->render('@Translation/WebUI/create.html.twig', [
             'message' => $message,
         ]);
     }


### PR DESCRIPTION
`:` way to call views is not supported anymore for Twig 2.x branch.

My fix is tested for an app with Twig 2.4, but not with Twig 1.x. But, as [Twig documentation explain](https://twig.symfony.com/doc/1.x/api.html#loaders) `@` namespace are supported.

Let me know for any improvement if necessary ;)