### PR TITLE
Tweak indentations to 4 spaces as in Symfony recipes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,13 +20,13 @@ $ composer require php-translation/symfony-bundle
 ```php
 class AppKernel extends Kernel
 {
-  public function registerBundles()
-  {
-    $bundles = array(
-        // ...
-        new Translation\Bundle\TranslationBundle(),
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+            new Translation\Bundle\TranslationBundle(),
+        }
     }
-  }
 }
 ```
 
@@ -35,38 +35,38 @@ An example configuration looks like this:
 ```yaml
 # config.yml
 translation:
-  locales: ["en", "sv"]
-  symfony_profiler: # must be placed in config_dev.yml
-    enabled: true
-  webui:
-    enabled: true
-  edit_in_place:
-    enabled: true
-    config_name: default # the first one or one of your configs
-    activator: php_translation.edit_in_place.activator
-  configs:
-    app:
-      dirs: ["%kernel.root_dir%/Resources/views", "%kernel.root_dir%/../src"]
-      output_dir: "%kernel.root_dir%/Resources/translations"
-      excluded_names: ["*TestCase.php", "*Test.php"]
-      excluded_dirs: [cache, data, logs]
+    locales: ["en", "sv"]
+    symfony_profiler: # must be placed in config_dev.yml
+        enabled: true
+    webui:
+        enabled: true
+    edit_in_place:
+        enabled: true
+        config_name: default # the first one or one of your configs
+        activator: php_translation.edit_in_place.activator
+    configs:
+        app:
+            dirs: ["%kernel.root_dir%/Resources/views", "%kernel.root_dir%/../src"]
+            output_dir: "%kernel.root_dir%/Resources/translations"
+            excluded_names: ["*TestCase.php", "*Test.php"]
+            excluded_dirs: [cache, data, logs]
 ```
 
 ```yaml
 # routing_dev.yml
 _translation_webui:
-  resource: "@TranslationBundle/Resources/config/routing_webui.yml"
-  prefix:  /admin
+    resource: "@TranslationBundle/Resources/config/routing_webui.yml"
+    prefix:  /admin
   
 _translation_profiler:
-  resource: '@TranslationBundle/Resources/config/routing_symfony_profiler.yml'
+    resource: '@TranslationBundle/Resources/config/routing_symfony_profiler.yml'
 ```
 
 ```yaml
 # routing.yml
 _translation_edit_in_place:
-  resource: '@TranslationBundle/Resources/config/routing_edit_in_place.yml'
-  prefix:  /admin
+    resource: '@TranslationBundle/Resources/config/routing_edit_in_place.yml'
+    prefix:  /admin
 ```
 
 ## Documentation


### PR DESCRIPTION
It's defacto standard, easy to copy/paste to existent projects, you don't need to re-indent pasted code