### PR TITLE
Correct translation fallback edition

### DIFF
--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -50,7 +50,7 @@ class SymfonyProfilerController extends Controller
 
             return $this->render('@Translation/SymfonyProfiler/edit.html.twig', [
                 'message' => $translation,
-                'key' => $message->getLocale().$message->getDomain().$message->getKey(),
+                'key' => $request->query->get('message_id'),
             ]);
         }
 


### PR DESCRIPTION
I solved this error by using message key from query parameter instead of current locale wich are different in case of the fallback translation, contrary to normal edition.

https://github.com/php-translation/symfony-bundle/issues/157