### PR TITLE
Removing empty messages in the total count in webui, gives a better progress

### DIFF
--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -58,7 +58,9 @@ class WebUIController extends Controller
             ksort($domains);
             $catalogueSize[$locale] = 0;
             foreach ($domains as $domain => $messages) {
-                $count = count($messages);
+                $count = count(array_filter($messages, function($message) {
+                    return $message !== '';
+                }));
                 $catalogueSize[$locale] += $count;
                 if (!isset($maxDomainSize[$domain]) || $count > $maxDomainSize[$domain]) {
                     $maxDomainSize[$domain] = $count;

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -58,8 +58,8 @@ class WebUIController extends Controller
             ksort($domains);
             $catalogueSize[$locale] = 0;
             foreach ($domains as $domain => $messages) {
-                $count = count(array_filter($messages, function($message) {
-                    return $message !== '';
+                $count = count(array_filter($messages, function ($message) {
+                    return '' !== $message;
                 }));
                 $catalogueSize[$locale] += $count;
                 if (!isset($maxDomainSize[$domain]) || $count > $maxDomainSize[$domain]) {


### PR DESCRIPTION
By removing empty messages in the progress counter, so it gives a more realistic overview of the progress counter in the webui