### PR TITLE
Feature/command obsolete

### DIFF
--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -55,40 +55,40 @@ class DeleteObsoleteCommand extends ContainerAwareCommand
         $messages = $catalogueManager->findMessages(['locale' => $inputLocale, 'isObsolete' => true]);
 
         $messageCount = count($messages);
-        if ($messageCount > 0) {
-            $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(sprintf('You are about to remove %d translations. Do you wish to continue? (y/N) ', $messageCount), false);
-            if (!$helper->ask($input, $output, $question)) {
-                return;
-            }
+        if ($messageCount === 0) {
+            $output->writeln('No messages are obsolete');
 
-            $progress = null;
-            if (OutputInterface::VERBOSITY_NORMAL === $output->getVerbosity() && OutputInterface::VERBOSITY_QUIET !== $output->getVerbosity()) {
-                $progress = new ProgressBar($output, $messageCount);
-            }
-            foreach ($messages as $message) {
-                $storage->delete($message->getLocale(), $message->getDomain(), $message->getKey());
-                if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
-                    $output->writeln(sprintf(
-                        'Deleted obsolete message "<info>%s</info>" from domain "<info>%s</info>" and locale "<info>%s</info>"',
-                        $message->getKey(),
-                        $message->getDomain(),
-                        $message->getLocale()
-                    ));
-                }
+            return;
+        }
 
-                if ($progress) {
-                    $progress->advance();
-                }
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(sprintf('You are about to remove %d translations. Do you wish to continue? (y/N) ', $messageCount), false);
+        if (!$helper->ask($input, $output, $question)) {
+            return;
+        }
+
+        $progress = null;
+        if (OutputInterface::VERBOSITY_NORMAL === $output->getVerbosity() && OutputInterface::VERBOSITY_QUIET !== $output->getVerbosity()) {
+            $progress = new ProgressBar($output, $messageCount);
+        }
+        foreach ($messages as $message) {
+            $storage->delete($message->getLocale(), $message->getDomain(), $message->getKey());
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+                $output->writeln(sprintf(
+                    'Deleted obsolete message "<info>%s</info>" from domain "<info>%s</info>" and locale "<info>%s</info>"',
+                    $message->getKey(),
+                    $message->getDomain(),
+                    $message->getLocale()
+                ));
             }
 
             if ($progress) {
-                $progress->finish();
+                $progress->advance();
             }
-            exit(0);
         }
 
-        $output->writeln('No messages are obsolete');
-
+        if ($progress) {
+            $progress->finish();
+        }
     }
 }

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -63,7 +63,7 @@ class DeleteObsoleteCommand extends ContainerAwareCommand
             }
 
             $progress = null;
-            if ($output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL && $output->getVerbosity() !== OutputInterface::VERBOSITY_QUIET) {
+            if (OutputInterface::VERBOSITY_NORMAL === $output->getVerbosity() && OutputInterface::VERBOSITY_QUIET !== $output->getVerbosity()) {
                 $progress = new ProgressBar($output, $messageCount);
             }
             foreach ($messages as $message) {

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -55,7 +55,7 @@ class DeleteObsoleteCommand extends ContainerAwareCommand
         $messages = $catalogueManager->findMessages(['locale' => $inputLocale, 'isObsolete' => true]);
 
         $messageCount = count($messages);
-        if ($messageCount === 0) {
+        if (0 === $messageCount) {
             $output->writeln('No messages are obsolete');
 
             return;

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -142,7 +142,7 @@ class TranslationExtension extends Extension
             // Create some aliases for the default storage
             $container->setAlias('php_translation.storage', new Alias('php_translation.storage.'.$first, true));
             if ('default' !== $first) {
-                $container->setAlias('php_translation.storage.default', 'php_translation.storage.'.$first);
+                $container->setAlias('php_translation.storage.default', new Alias('php_translation.storage.'.$first, true));
             }
         }
     }


### PR DESCRIPTION
* Setting the php_translation.storage.default to public, due to its required by the obsolete command
* Updated obsolete command, so you will get better overview of what has been removed if you add -v
* Dont ask for anything if there are 0 obsolete messages
* Dont add progressbar if -q is added