### PR TITLE
Make activator service public

### DIFF
--- a/Resources/config/edit_in_place.yml
+++ b/Resources/config/edit_in_place.yml
@@ -13,6 +13,7 @@ services:
   php_translation.edit_in_place.activator:
     class: Translation\Bundle\EditInPlace\Activator
     arguments: ['@session']
+    public: true
 
   php_translator.edit_in_place.xtrans_html_translator:
     class: Translation\Bundle\Translator\EditInPlaceTranslator


### PR DESCRIPTION
The `php_translation.edit_in_place.activator` service should be public to make the instructions from http://php-translation.readthedocs.io/en/latest/symfony/edit-in-place.html work