### PR TITLE
Fixed issue with auto added translations with options

### DIFF
--- a/EventListener/AutoAddMissingTranslations.php
+++ b/EventListener/AutoAddMissingTranslations.php
@@ -50,7 +50,7 @@ final class AutoAddMissingTranslations
         $messages = $this->dataCollector->getCollectedMessages();
         foreach ($messages as $message) {
             if (DataCollectorTranslator::MESSAGE_MISSING === $message['state']) {
-                $m = new Message($message['id'], $message['domain'], $message['locale'], $message['translation']);
+                $m = new Message($message['id'], $message['domain'], $message['locale'], $message['id']);
                 $this->storage->create($m);
             }
         }


### PR DESCRIPTION
The issue was, that an auto added translation with options like this:
```
{{ "Next date is #date# "|trans({'#date#':dateItem.format('d.m.Y')}) }}
```
resulted in
```
<unit id="AtArHZK">
      <segment>
        <source>Next date is #date#</source>
        <target>Next date is 2018-02-19</target>
      </segment>
    </unit>
```
