### PR TITLE
Remove useless array wrapping

### DIFF
--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -134,7 +134,7 @@ class TranslationExtension extends Extension
 
                 $def = $this->createChildDefinition($serviceId);
                 $def->replaceArgument(2, [$c['output_dir']])
-                    ->replaceArgument(3, [$c['local_file_storage_options']])
+                    ->replaceArgument(3, $c['local_file_storage_options'])
                     ->addTag('php_translation.storage', ['type' => 'local', 'name' => $name]);
                 $container->setDefinition('php_translation.single_storage.file.'.$name, $def);
             }


### PR DESCRIPTION
We already check that it's an array in the configuration definition.
This wraps the option array in another array, so the argument passed in the storage is "double wrapped" and cannot be properly used.

https://github.com/php-translation/symfony-storage/blob/e4446fe5243f5380df865d763564b28498b209ef/src/FileStorage.php#L60-L79