### PR TITLE
Get rid of bootstrap overrides

### DIFF
--- a/Resources/public/css/webui.css
+++ b/Resources/public/css/webui.css
@@ -1,8 +1,8 @@
 /* Navigation */
-.navbar {
+#configs {
     padding: 0 2rem;
 }
-.navbar-nav .nav-text{
+#configs .navbar-nav .nav-text{
     font-weight: bold;
     padding-top: 0.2rem;
     padding-bottom: 0;
@@ -10,7 +10,7 @@
     width: 6rem;
 }
 
-.navbar-nav .nav-link {
+#configs .navbar-nav .nav-link {
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;
 }

--- a/Resources/views/WebUI/base.html.twig
+++ b/Resources/views/WebUI/base.html.twig
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<nav class="navbar navbar-light bg-faded">
+<nav id="configs" class="navbar navbar-light bg-faded">
     <ul class="nav navbar-nav">
         <li class="nav-item"><span class="nav-text">Configs:</span></li>
         {% for c in configNames %}


### PR DESCRIPTION
If I change the layout to integrate another one, I have some css overrides in webui.css. This remove bootstrap overrides for navbar