### PR TITLE
Fix the FileDumper::setBackup() method deprecation notice

### DIFF
--- a/DependencyInjection/CompilerPass/FileDumperBackupPass.php
+++ b/DependencyInjection/CompilerPass/FileDumperBackupPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Translation\Bundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -15,9 +24,11 @@ class FileDumperBackupPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (Kernel::MAJOR_VERSION <= 3) {
-            $definition = $container->getDefinition('php_translation.storage.xlf_dumper');
-            $definition->addMethodCall('setBackup', [false]);
+        if (Kernel::MAJOR_VERSION >= 4) {
+            return;
         }
+
+        $definition = $container->getDefinition('php_translation.storage.xlf_dumper');
+        $definition->addMethodCall('setBackup', [false]);
     }
 }

--- a/DependencyInjection/CompilerPass/FileDumperBackupPass.php
+++ b/DependencyInjection/CompilerPass/FileDumperBackupPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Translation\Bundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * The FileDumper::setBackup is deprecated since Symfony 4.1.
+ * This compiler pass assures our service definition remains unchanged for older symfony versions (3 or lower)
+ * while keeping the latest version clean of deprecation notices.
+ */
+class FileDumperBackupPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (Kernel::MAJOR_VERSION <= 3) {
+            $definition = $container->getDefinition('php_translation.storage.xlf_dumper');
+            $definition->addMethodCall('setBackup', [false]);
+        }
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -53,8 +53,6 @@ services:
     class: Translation\SymfonyStorage\Dumper\XliffDumper
     tags:
       - { name: translation.dumper, alias: xlf, legacy-alias: xliff }
-    calls:
-      - [setBackup, [false]]
 
   php_translation.catalogue_counter:
     public: true

--- a/TranslationBundle.php
+++ b/TranslationBundle.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Translation\Bundle\DependencyInjection\CompilerPass\EditInPlacePass;
 use Translation\Bundle\DependencyInjection\CompilerPass\ExternalTranslatorPass;
 use Translation\Bundle\DependencyInjection\CompilerPass\ExtractorPass;
+use Translation\Bundle\DependencyInjection\CompilerPass\FileDumperBackupPass;
 use Translation\Bundle\DependencyInjection\CompilerPass\LoaderOrReaderPass;
 use Translation\Bundle\DependencyInjection\CompilerPass\StoragePass;
 use Translation\Bundle\DependencyInjection\CompilerPass\SymfonyProfilerPass;
@@ -35,5 +36,6 @@ class TranslationBundle extends Bundle
         $container->addCompilerPass(new StoragePass());
         $container->addCompilerPass(new EditInPlacePass());
         $container->addCompilerPass(new LoaderOrReaderPass());
+        $container->addCompilerPass(new FileDumperBackupPass());
     }
 }


### PR DESCRIPTION
Heya :wave: 

This PR should fix the deprecation notices for https://github.com/symfony/translation/blob/4.1/Dumper/FileDumper.php#L52 

If you have any additions or changes I'd love to know. 