### PR TITLE
Set the twig strict_variables settings to suppress the deprecation not…

### DIFF
--- a/Tests/Functional/app/config/framework.yml
+++ b/Tests/Functional/app/config/framework.yml
@@ -14,5 +14,6 @@ framework:
         engines: ['twig']
 
 twig:
+  strict_variables: "%kernel.debug%" #supresses deprecation notices about the default value TwigBundle pre version 5
   paths:
     "%test.root_dir%/Resources/views": App


### PR DESCRIPTION
Hi again! :wave: 

I thought I'd get rid of the deprecation notice in the twig bundle while building for Symfony 4. Note that this is a behavioral change: the default value is 'false' compared to the new default value of '%kernel.debug%' which eventually evaluates to true when running the tests. Since it seems that this configuration is only used in the functional tests, there should be nothing functionally breaking in the bundle.

But, what does `strict_variables` do?

> If set to false, Twig will silently ignore invalid variables (variables and or attributes/methods that do not exist) and replace them with a null value. When set to true, Twig throws an exception instead. - [Twig documentation](https://twig.symfony.com/doc/2.x/api.html)

## What has been changed?
- In order to suppress the twig deprecation warnings, I've set the strict_variables: setting to "%kernel.debug%"

## How to test:
- Compare the SF4 build of this PR vs [the one in master](https://travis-ci.org/php-translation/symfony-bundle/jobs/390162490). It should no longer state 
```
28x: Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.
```

## Notes:
This PR is build upon the assumption that the line causing deprecation warnings was only used for functional testing.