### PR TITLE
Ensure storage exists before using it in commands

### DIFF
--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -28,14 +28,9 @@ use Translation\Bundle\Service\StorageManager;
  */
 class DeleteObsoleteCommand extends Command
 {
-    use BundleTrait;
+    use BundleTrait, StorageTrait;
 
     protected static $defaultName = 'translation:delete-obsolete';
-
-    /**
-     * @var StorageManager
-     */
-    private $storageManager;
 
     /**
      * @var ConfigurationManager
@@ -94,7 +89,7 @@ class DeleteObsoleteCommand extends Command
         $this->configureBundleDirs($input, $config);
         $this->catalogueManager->load($this->catalogueFetcher->getCatalogues($config, $locales));
 
-        $storage = $this->storageManager->getStorage($configName);
+        $storage = $this->getStorage($configName);
         $messages = $this->catalogueManager->findMessages(['locale' => $inputLocale, 'isObsolete' => true]);
 
         $messageCount = count($messages);

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -27,14 +27,9 @@ use Translation\Bundle\Model\Configuration;
  */
 class DownloadCommand extends Command
 {
-    use BundleTrait;
+    use BundleTrait, StorageTrait;
 
     protected static $defaultName = 'translation:download';
-
-    /**
-     * @var StorageManager
-     */
-    private $storageManager;
 
     /**
      * @var ConfigurationManager
@@ -76,7 +71,7 @@ class DownloadCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $configName = $input->getArgument('configuration');
-        $storage = $this->storageManager->getStorage($configName);
+        $storage = $this->getStorage($configName);
         $configuration = $this->configurationManager->getConfiguration($configName);
 
         $this->configureBundleDirs($input, $configuration);

--- a/Command/StorageTrait.php
+++ b/Command/StorageTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Command;
+
+use Translation\Bundle\Service\StorageManager;
+
+trait StorageTrait
+{
+    /**
+     * @var StorageManager
+     */
+    private $storageManager;
+
+    private function getStorage($configName)
+    {
+        if (null === $storage = $this->storageManager->getStorage($configName)) {
+            $availableStorages = $this->storageManager->getNames();
+
+            throw new \InvalidArgumentException(sprintf('Unknown storage "%s". Available storages are "%s".', $configName, implode('", "', $availableStorages)));
+        }
+    }
+}

--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -23,12 +23,9 @@ use Translation\Bundle\Service\StorageService;
  */
 class SyncCommand extends Command
 {
-    protected static $defaultName = 'translation:sync';
+    use StorageTrait;
 
-    /**
-     * @var StorageManager
-     */
-    private $storageManager;
+    protected static $defaultName = 'translation:sync';
 
     /**
      * @param StorageManager $storageManager
@@ -66,7 +63,6 @@ class SyncCommand extends Command
                 return;
         }
 
-        $configName = $input->getArgument('configuration');
-        $this->storageManager->getStorage($configName)->sync($direction);
+        $this->getStorage($input->getArgument('configuration'))->sync($direction);
     }
 }

--- a/Tests/Functional/Command/SyncCommandTest.php
+++ b/Tests/Functional/Command/SyncCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Translation\Bundle\Tests\Functional\BaseTestCase;
+
+class SyncCommandTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
+
+        file_put_contents(__DIR__.'/../app/Resources/translations/messages.sv.xlf', <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+    <file id="messages.en_US">
+    <unit id="xx1">
+      <segment>
+        <source>translated.heading</source>
+        <target>My translated heading</target>
+      </segment>
+    </unit>
+    <unit id="xx2">
+      <segment>
+        <source>translated.paragraph0</source>
+        <target>My translated paragraph0</target>
+      </segment>
+    </unit>
+    <unit id="xx3">
+      <notes>
+        <note category="file-source" priority="1">foobar.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>translated.paragraph1</source>
+        <target>My translated paragraph1</target>
+      </segment>
+    </unit>
+    <unit id="xx4">
+      <segment>
+        <source>not.in.source</source>
+        <target>This is not in the source code</target>
+      </segment>
+    </unit>
+    </file>
+</xliff>
+
+XML
+        );
+    }
+
+    public function testExecute()
+    {
+        $this->bootKernel();
+        $application = new Application($this->kernel);
+
+        $container = $this->getContainer();
+        $application->add($container->get('php_translator.console.sync'));
+
+        $command = $application->find('translation:sync');
+        $commandTester = new CommandTester($command);
+
+        try {
+            $commandTester->execute([
+                'command' => $command->getName(),
+                'configuration' => 'fail',
+            ]);
+
+            $this->fail('The command should fail when called with an unknown configuration key.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertRegExp('|Unknown storage "fail"\.|s', $e->getMessage());
+            $this->assertRegExp('|Available storages are "app"\.|s', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Avoid weird errors like `Call to a member function sync() on null` for example.