### PR TITLE
Only measure code coverage on Unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
         - env: STABILITY="dev"
 
 before_install:
-    - if [[ $COVERAGE == true ]]; then echo "max_execution_time = 600" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
     - if ! [ -z "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "scripts": {
         "test": "vendor/bin/simple-phpunit",
-        "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml Tests/Unit"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
It takes too much time to see code coverage on the functional tests. PHPUnit has to keep track on all the Symfony stack. 