### PR TITLE
From SF profiler, use storage that match config instead of default one

### DIFF
--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -109,6 +109,10 @@ final class Configuration
         $this->blacklistDomains = $data['blacklist_domains'];
         $this->whitelistDomains = $data['whitelist_domains'];
         $this->xliffVersion = $data['xliff_version'];
+
+        if ($this->blacklistDomains && $this->whitelistDomains) {
+            throw new \LogicException('Cannot use blacklist_domains and blacklist_domains at the same time');
+        }
     }
 
     /**
@@ -197,6 +201,26 @@ final class Configuration
     public function getWhitelistDomains()
     {
         return $this->whitelistDomains;
+    }
+
+    /**
+     * If the domain
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomain($domain)
+    {
+        if (in_array($domain, $this->getWhitelistDomains(), true)) {
+            return true;
+        }
+
+        if (in_array($domain, $this->getBlacklistDomains(), true)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -24,6 +24,7 @@ services:
   php_translation.storage_manager:
     public: true
     class: Translation\Bundle\Service\StorageManager
+    arguments: ["@php_translation.configuration_manager"]
 
   php_translation.configuration_manager:
     public: true

--- a/Service/ConfigurationManager.php
+++ b/Service/ConfigurationManager.php
@@ -23,7 +23,7 @@ final class ConfigurationManager
     /**
      * @var Configuration[]
      */
-    private $configuration = [];
+    private $configurations = [];
 
     /**
      * @param string        $name
@@ -31,11 +31,11 @@ final class ConfigurationManager
      */
     public function addConfiguration($name, Configuration $configuration)
     {
-        $this->configuration[$name] = $configuration;
+        $this->configurations[$name] = $configuration;
     }
 
     /**
-     * @param string $name
+     * @param null|string $name
      *
      * @return null|Configuration
      */
@@ -45,16 +45,36 @@ final class ConfigurationManager
             return $this->getConfiguration('default');
         }
 
-        if (isset($this->configuration[$name])) {
-            return $this->configuration[$name];
+        if (isset($this->configurations[$name])) {
+            return $this->configurations[$name];
         }
 
         if ('default' === $name) {
             $name = $this->getFirstName();
-            if (isset($this->configuration[$name])) {
-                return $this->configuration[$name];
+            if (isset($this->configurations[$name])) {
+                return $this->configurations[$name];
             }
         }
+    }
+
+    /**
+     * @param null|string $domain
+     *
+     * @return null|Configuration
+     */
+    public function getConfigurationByDomain($domain = null)
+    {
+        if (empty($domain)) {
+            return $this->getConfiguration('default');
+        }
+
+        foreach($this->configurations as $configuration) {
+            if ($configuration->hasDomain($domain)) {
+                return $configuration;
+            }
+        }
+
+        return $this->getConfiguration('default');
     }
 
     /**
@@ -62,7 +82,7 @@ final class ConfigurationManager
      */
     public function getFirstName()
     {
-        foreach ($this->configuration as $name => $config) {
+        foreach ($this->configurations as $name => $config) {
             return $name;
         }
     }
@@ -72,6 +92,6 @@ final class ConfigurationManager
      */
     public function getNames()
     {
-        return array_keys($this->configuration);
+        return array_keys($this->configurations);
     }
 }

--- a/Service/StorageManager.php
+++ b/Service/StorageManager.php
@@ -24,6 +24,16 @@ final class StorageManager
     private $storages = [];
 
     /**
+     * @var ConfigurationManager
+     */
+    private $configurationManager;
+
+    public function __construct(ConfigurationManager $configurationManager)
+    {
+        $this->configurationManager = $configurationManager;
+    }
+
+    /**
      * @param string         $name
      * @param StorageService $storage
      */
@@ -53,6 +63,26 @@ final class StorageManager
                 return $this->storages[$name];
             }
         }
+    }
+
+    /**
+     * @return StorageService[]
+     */
+    public function getStorages()
+    {
+        return $this->storages;
+    }
+
+    /**
+     * @param string $domain
+     *
+     * @return null|StorageService
+     */
+    public function getStorageByDomain($domain)
+    {
+        $configuration = $this->configurationManager->getConfigurationByDomain($domain);
+
+        return $this->getStorage($configuration->getName());
     }
 
     /**


### PR DESCRIPTION
Hello,

I configured the bundle to use 2 configs: one with remote storage, one without remote storage.

Here is the full config:

```yaml
translation:
    http_client: 'httplug.client.translation'
    locales: '%supported_locales%'
    edit_in_place:
        enabled: false
        config_name: front
    configs:
        admin:
            dirs: ["%kernel.project_dir%/templates/admin", "%kernel.project_dir%/src"]
            output_dir: "%kernel.project_dir%/translations"
            output_format: xlf
            blacklist_domains: ['messages']

        front:
            dirs:
                [
                    '%kernel.project_dir%/templates/front',
                    '%kernel.project_dir%/src',
                ]
            output_dir: '%kernel.project_dir%/translations'
            output_format: xlf
            whitelist_domains: ['messages']
            remote_storage: ['php_translation.adapter.loco']

translation_adapter_loco:
    projects:
        messages:
            api_key: '%env(LOCO_API_KEY)%'
```

The problem was that I was not able to add keys from Symfony profiler page anymore.

Here is a proposal that uses whitelist_domains and blacklist_domains of the bundle config.

It's currently a draft that looks to work from my tests.

If everybody is ok I'll finish it with proper testing and anything required to get it done so let me know for anything :-)

Cheers

TODO

- [ ] tests
- [ ] doc