### PR TITLE
Create Composer\ScriptHandler class

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Composer;
+
+use Composer\Script\Event;
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseScriptHandler;
+
+class ScriptHandler extends BaseScriptHandler
+{
+    /**
+     * Dumps translations of the project.
+     *
+     * @param Event $event
+     */
+    public static function translationDownload(Event $event)
+    {
+        $options = self::getOptions($event);
+        $consoleDir = static::getConsoleDir($event, 'clear the cache');
+
+        if (null === $consoleDir) {
+            return;
+        }
+
+        static::executeCommand($event, $consoleDir, 'translation:download --cache');
+    }
+}


### PR DESCRIPTION
The aim of this PR is to permits to execute translation:download command from the composer command.

When you deploy your project, translations will be automatically downloaded from your remote storage.

```json
  "scripts": {
    "symfony-scripts": [
      "Translation\\Bundle\\Composer\\ScriptHandler::translationDownload"
    ],
    "post-install-cmd": [
      "@symfony-scripts"
    ],
    "post-update-cmd": [
      "@symfony-scripts"
    ]
```

To do so, I have extended the ScriptHandler class from the Sensio Distribution Bundle.