### PR TITLE
[Service/Importer.php] Fix default translation conditional assignment

### DIFF
--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -110,7 +110,7 @@ final class Importer
                             $result->set($key, $newTranslation, $domain);
                             // We do not want "translation" key stored anywhere.
                             $meta->removeAllInCategory('translation');
-                        } elseif (null !== $newTranslation = $meta->getDesc() && $catalogue->getLocale() === $this->defaultLocale) {
+                        } elseif ((null !== $newTranslation = $meta->getDesc()) && $catalogue->getLocale() === $this->defaultLocale) {
                             $result->set($key, $newTranslation, $domain);
                         }
                     }


### PR DESCRIPTION
Solving this message https://github.com/php-translation/symfony-bundle/issues/223#issuecomment-408324977 (because I need this too :slightly_smiling_face:)
Without parenthesis the result in <target> of default locale messages is like this:
```xml
    <unit id="CBAl84X" name="dashboard_title_tag">
      <notes>
        <note category="file-source" priority="1">templates/default/dashboard.html.twig:6</note>
        <note category="desc" priority="1">Dashboard</note>
        <note category="state" priority="1">new</note>
      </notes>
      <segment>
        <source>dashboard_title_tag</source>
        <target>1</target>
      </segment>
    </unit>
```

and this fixes it and shows expected default message:
```xml
    <unit id="CBAl84X" name="dashboard_title_tag">
      <notes>
        <note category="file-source" priority="1">templates/default/dashboard.html.twig:6</note>
        <note category="desc" priority="1">Dashboard</note>
        <note category="state" priority="1">new</note>
      </notes>
      <segment>
        <source>dashboard_title_tag</source>
        <target>Dashboard</target>
      </segment>
    </unit>
```