### PR TITLE
[EditInPlace] Fix bad HTML generation when there is HTML in the translation

### DIFF
--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -62,8 +62,8 @@ final class EditInPlaceTranslatorTest extends TestCase
     {
         $symfonyTranslator = new \Symfony\Component\Translation\Translator('en', null, null, true);
         $symfonyTranslator->addLoader('array', new ArrayLoader());
-        $symfonyTranslator->addResource('array', array('foo' => 'Normal content.'), 'en');
-        $symfonyTranslator->addResource('array', array('bar' => 'Content with <b>HTML</b> in it.'), 'en');
+        $symfonyTranslator->addResource('array', ['foo' => 'Normal content.'], 'en');
+        $symfonyTranslator->addResource('array', ['bar' => 'Content with <b>HTML</b> in it.'], 'en');
 
         $request = new Request();
         $requestStack = new RequestStack();

--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -64,6 +64,7 @@ final class EditInPlaceTranslatorTest extends TestCase
         $symfonyTranslator->addLoader('array', new ArrayLoader());
         $symfonyTranslator->addResource('array', ['foo' => 'Normal content.'], 'en');
         $symfonyTranslator->addResource('array', ['bar' => 'Content with <b>HTML</b> in it.'], 'en');
+        $symfonyTranslator->addResource('array', ['bar.attr' => 'Content with <b class="alert">HTML</b> in it.'], 'en');
 
         $request = new Request();
         $requestStack = new RequestStack();
@@ -78,8 +79,13 @@ final class EditInPlaceTranslatorTest extends TestCase
         );
 
         $this->assertSame(
-            'Content with <b>HTML</b> in it.',
+            '<x-trans data-key="messages|bar" data-value="Content with &lt;b&gt;HTML&lt;/b&gt; in it." data-plain="Content with &lt;b&gt;HTML&lt;/b&gt; in it." data-domain="messages" data-locale="en">Content with <b>HTML</b> in it.</x-trans>',
             $service->trans('bar', [])
+        );
+
+        $this->assertSame(
+            '<x-trans data-key="messages|bar.attr" data-value="Content with &lt;b class=&quot;alert&quot;&gt;HTML&lt;/b&gt; in it." data-plain="Content with &lt;b class=&quot;alert&quot;&gt;HTML&lt;/b&gt; in it." data-domain="messages" data-locale="en">Content with <b class="alert">HTML</b> in it.</x-trans>',
+            $service->trans('bar.attr', [])
         );
     }
 }

--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Tests\Unit\Translator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\TranslatorInterface;
+use Translation\Bundle\EditInPlace\ActivatorInterface;
+use Translation\Bundle\Translator\EditInPlaceTranslator;
+
+/**
+ * @author Damien Alexandre <dalexandre@jolicode.com>
+ */
+final class EditInPlaceTranslatorTest extends TestCase
+{
+    public function testEnabled()
+    {
+        $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
+
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $activator = new FakeActivator(true);
+        $service = new EditInPlaceTranslator($symfonyTranslator, $activator, $requestStack);
+
+        $this->assertSame(
+            '<x-trans data-key="messages|key" data-value="" data-plain="" data-domain="messages" data-locale=""></x-trans>',
+            $service->trans('key', [])
+        );
+    }
+
+    public function testDisabled()
+    {
+        $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
+
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $activator = new FakeActivator(false);
+        $service = new EditInPlaceTranslator($symfonyTranslator, $activator, $requestStack);
+
+        $this->assertSame(
+            null,
+            $service->trans('key', [])
+        );
+    }
+
+    public function testHtmlTranslation()
+    {
+        $symfonyTranslator = new \Symfony\Component\Translation\Translator('en', null, null, true);
+        $symfonyTranslator->addLoader('array', new ArrayLoader());
+        $symfonyTranslator->addResource('array', array('foo' => 'Normal content.'), 'en');
+        $symfonyTranslator->addResource('array', array('bar' => 'Content with <b>HTML</b> in it.'), 'en');
+
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $activator = new FakeActivator(true);
+        $service = new EditInPlaceTranslator($symfonyTranslator, $activator, $requestStack);
+
+        $this->assertSame(
+            '<x-trans data-key="messages|foo" data-value="Normal content." data-plain="Normal content." data-domain="messages" data-locale="en">Normal content.</x-trans>',
+            $service->trans('foo', [])
+        );
+
+        $this->assertSame(
+            'Content with <b>HTML</b> in it.',
+            $service->trans('bar', [])
+        );
+    }
+}
+
+class FakeActivator implements ActivatorInterface
+{
+    private $enabled;
+
+    public function __construct($enabled = true)
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function checkRequest(Request $request = null)
+    {
+        return $this->enabled;
+    }
+}

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -64,7 +64,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
         }
 
         // If there is HTML in the translation, do not allow EditInPlace (it broke Content Tools)
-        if (strpos($original, '<') !== false) {
+        if (false !== strpos($original, '<')) {
             return $original;
         }
 

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -63,6 +63,11 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
             return $original;
         }
 
+        // If there is HTML in the translation, do not allow EditInPlace (it broke Content Tools)
+        if (strpos($original, '<') !== false) {
+            return $original;
+        }
+
         $plain = $this->translator->trans($id, [], $domain, $locale);
 
         if (null === $domain) {

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -63,11 +63,6 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
             return $original;
         }
 
-        // If there is HTML in the translation, do not allow EditInPlace (it broke Content Tools)
-        if (false !== strpos($original, '<')) {
-            return $original;
-        }
-
         $plain = $this->translator->trans($id, [], $domain, $locale);
 
         if (null === $domain) {
@@ -81,8 +76,8 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
         return sprintf('<x-trans data-key="%s|%s" data-value="%s" data-plain="%s" data-domain="%s" data-locale="%s">%s</x-trans>',
             $domain,
             $id,
-            $original,
-            $plain,
+            htmlspecialchars($original),
+            htmlspecialchars($plain),
             $domain,
             $locale,
             $original


### PR DESCRIPTION
An error could occur when using Edit In Place with HTML in the translations:

```
Uncaught DOMException: Failed to execute 'setAttribute' on 'Element': 'show-for-custom-md"' is not a valid attribute name.
    at c.mount (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:3:20706)
    at new c (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:3:12341)
    at c._initRegions (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:6:24008)
    at c.start (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:6:20300)
    at b.<anonymous> (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:6:14355)
    at b.a.dispatchEvent (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:4:24074)
    at b.edit (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:4:27817)
    at HTMLDivElement.<anonymous> (http://notarealwebsite.com:8000/bundles/translation/js/content-tools.min.js?9:4:29468)
c.mount @ content-tools.min.js?9:formatted:2749
c @ content-tools.min.js?9:formatted:2418
c._initRegions @ content-tools.min.js?9:formatted:6656
c.start @ content-tools.min.js?9:formatted:6508
(anonymous) @ content-tools.min.js?9:formatted:6251
a.dispatchEvent @ content-tools.min.js?9:formatted:4299
b.edit @ content-tools.min.js?9:formatted:4482
(anonymous) @ content-tools.min.js?9:formatted:4524
```

Is was caused by the Translator, as we transform the translation to wrap them in a `x-trans` HTML tag, and the translation is set as an attribute of that tag, the bundle was building invalid HTML. 

~This PR remove the ability to Edit In Place a translation where HTML has been put, and also add tests.~

This PR fix the generated HTML output and adds tests.