### PR TITLE
[EditInPlaceListener] Test if response content is false

### DIFF
--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -84,6 +84,10 @@ HTML;
 
         $content = $event->getResponse()->getContent();
 
+        if (false === $content) {
+            return;
+        }
+
         // Clean the content for malformed tags in attributes or encoded tags
         $replacement = "\"$1🚫 Can't be translated here. 🚫\"";
         $pattern = "@\\s*[\"']\\s*(.[a-zA-Z]+:|)(<x-trans.+data-value=\"([^&\"]+)\".+?(?=<\\/x-trans)<\\/x-trans>)\\s*[\"']@mi";


### PR DESCRIPTION
I encountered an error with the EditInPlaceListener, when you try to return a BinaryResponse, a test is done to check if the content is null, if not, it throw an error.

But with the EditInPlace enabled, the content is always changed to an empty string, then it fail: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php#L315

I just add a test to check if the ->getContent return false, in this case we return and abort the edit in place listener action.