### PR TITLE
WebUI - Template block names

### DIFF
--- a/Resources/views/WebUI/base.html.twig
+++ b/Resources/views/WebUI/base.html.twig
@@ -26,9 +26,9 @@
     </div>
 </nav>
 
-{% block body %}{% endblock %}
+{% block _translation_bundle_body %}{% endblock %}
 
-{% block javascripts %}
+{% block _translation_bundle_js %}
     <script type="text/javascript" src="{{ asset("bundles/translation/js/webui.js") }}"></script>
 {% endblock %}
 

--- a/Resources/views/WebUI/index.html.twig
+++ b/Resources/views/WebUI/index.html.twig
@@ -1,7 +1,7 @@
 {% extends "@Translation/WebUI/base.html.twig" %}
 {% import _self as macro %}
 
-{% block body %}
+{% block _translation_bundle_body %}
     <div class="container">
         {% for cataloge in catalogues %}
             <h3 class="mt-3">{{ localeMap[cataloge.locale] }}</h3>

--- a/Resources/views/WebUI/show.html.twig
+++ b/Resources/views/WebUI/show.html.twig
@@ -1,7 +1,7 @@
 {% extends "@Translation/WebUI/base.html.twig" %}
 {% import _self as macro %}
 
-{% block body %}
+{% block _translation_bundle_body %}
     <div class="container locales">
         <h5 class="mt-2">Locales:</h5>
         {% for locale in locales %}
@@ -63,7 +63,7 @@
     </div>
 {% endblock %}
 
-{% block javascripts %}
+{% block _translation_bundle_js %}
     <script type="text/javascript">
       var editUrl = "{{ path('translation_edit', {configName: configName, locale:currentLocale,domain:currentDomain}) }}";
     </script>


### PR DESCRIPTION
Changed the block names, so its not using the "default" ones, so its much easier to overwrite the base template, so it can be fitted into your own admin view.

So you doesnt need to overwrite 3 templates, but can overwrite just the base template