### PR TITLE
Update EditInPlaceTranslator.php

### DIFF
--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -12,7 +12,7 @@
 namespace Translation\Bundle\Translator;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
 


### PR DESCRIPTION
`The "Translation\Bundle\Translator\EditInPlaceTranslator" class implements "Symfony\Component\Translation\TranslatorInterface" that is deprecated since Symfony 4.2, use Symfony\Contracts\Translation\TranslatorInterface instead.`