### PR TITLE
chore(twig): replace class aliases by class namespaces

### DIFF
--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -21,6 +21,7 @@ use Translation\Extractor\Extractor;
 use Translation\Extractor\Model\SourceCollection;
 use Translation\Extractor\Model\SourceLocation;
 use Translation\Bundle\Catalogue\Operation\ReplaceOperation;
+use Twig\Environment;
 
 /**
  * Use extractors to import translations to message catalogues.
@@ -40,7 +41,7 @@ final class Importer
     private $config;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -50,11 +51,11 @@ final class Importer
     private $defaultLocale;
 
     /**
-     * @param Extractor         $extractor
-     * @param \Twig_Environment $twig
-     * @param string            $defaultLocale
+     * @param Extractor   $extractor
+     * @param Environment $twig
+     * @param string      $defaultLocale
      */
-    public function __construct(Extractor $extractor, \Twig_Environment $twig, $defaultLocale)
+    public function __construct(Extractor $extractor, Environment $twig, $defaultLocale)
     {
         $this->extractor = $extractor;
         $this->twig = $twig;

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -18,7 +18,6 @@ use Symfony\Component\Translation\MessageSelector;
 use Translation\Bundle\Twig\TranslationExtension;
 use Twig\Loader\ArrayLoader;
 use Twig\Environment;
-use Twig\Loader\ArrayLoader;
 use Twig\Source;
 
 /**
@@ -37,6 +36,6 @@ abstract class BaseTwigTestCase extends TestCase
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
-        return $env->parse($env->tokenize(new Source($content, null)))->getNode('body');
+        return $env->parse($env->tokenize(new Source($content, '')))->getNode('body');
     }
 }

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -12,11 +12,14 @@
 namespace Translation\Bundle\Tests\Unit\Twig;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\MessageSelector;
-use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
+use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Translation\MessageSelector;
 use Translation\Bundle\Twig\TranslationExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Source;
 
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -30,10 +33,10 @@ abstract class BaseTwigTestCase extends TestCase
         $loader = class_exists(ArrayLoader::class)
             ? new ArrayLoader()
             : new \Twig_Loader_Array([]);
-        $env = new \Twig_Environment($loader);
+        $env = new Environment($loader);
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
-        return $env->parse($env->tokenize(new \Twig_Source($content, '')))->getNode('body');
+        return $env->parse($env->tokenize(new Source($content, null)))->getNode('body');
     }
 }

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -13,6 +13,7 @@ namespace Translation\Bundle\Twig;
 
 use Symfony\Component\HttpFoundation\RequestStack;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
+use Twig\TwigFilter;
 
 /**
  * Override the `trans` functions `is_safe` option to allow HTML output from the
@@ -38,8 +39,8 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('trans', [$this, 'trans'], ['is_safe_callback' => [$this, 'isSafe']]),
-            new \Twig_SimpleFilter('transchoice', [$this, 'transchoice'], ['is_safe_callback' => [$this, 'isSafe']]),
+            new TwigFilter('trans', [$this, 'trans'], ['is_safe_callback' => [$this, 'isSafe']]),
+            new TwigFilter('transchoice', [$this, 'transchoice'], ['is_safe_callback' => [$this, 'isSafe']]),
         ];
     }
 

--- a/Twig/Node/Transchoice.php
+++ b/Twig/Node/Transchoice.php
@@ -11,14 +11,18 @@
 
 namespace Translation\Bundle\Twig\Node;
 
-class Transchoice extends \Twig_Node_Expression
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\ArrayExpression;
+
+class Transchoice extends AbstractExpression
 {
-    public function __construct(\Twig_Node_Expression_Array $arguments, $lineno)
+    public function __construct(ArrayExpression $arguments, $lineno)
     {
         parent::__construct(['arguments' => $arguments], [], $lineno);
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler->raw(
             sprintf(

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -15,12 +15,14 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Translation\Bundle\Twig\Visitor\DefaultApplyingNodeVisitor;
 use Translation\Bundle\Twig\Visitor\NormalizingNodeVisitor;
 use Translation\Bundle\Twig\Visitor\RemovingNodeVisitor;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class TranslationExtension extends \Twig_Extension
+final class TranslationExtension extends AbstractExtension
 {
     /**
      * @var TranslatorInterface
@@ -48,8 +50,8 @@ final class TranslationExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('desc', [$this, 'desc']),
-            new \Twig_SimpleFilter('meaning', [$this, 'meaning']),
+            new TwigFilter('desc', [$this, 'desc']),
+            new TwigFilter('meaning', [$this, 'meaning']),
         ];
     }
 

--- a/Twig/Visitor/NormalizingNodeVisitor.php
+++ b/Twig/Visitor/NormalizingNodeVisitor.php
@@ -11,6 +11,12 @@
 
 namespace Translation\Bundle\Twig\Visitor;
 
+use Twig\Environment;
+use Twig\Node\Expression\Binary\ConcatBinary;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+
 /**
  * Performs equivalence transformations on the AST to ensure that
  * subsequent visitors do not need to be aware of different syntaxes.
@@ -19,31 +25,31 @@ namespace Translation\Bundle\Twig\Visitor;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class NormalizingNodeVisitor extends \Twig_BaseNodeVisitor
+final class NormalizingNodeVisitor extends AbstractNodeVisitor
 {
     /**
-     * @param \Twig_Node        $node
-     * @param \Twig_Environment $env
+     * @param Node        $node
+     * @param Environment $env
      *
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(Node $node, Environment $env)
     {
         return $node;
     }
 
     /**
-     * @param \Twig_Node        $node
-     * @param \Twig_Environment $env
+     * @param Node        $node
+     * @param Environment $env
      *
-     * @return \Twig_Node_Expression_Constant|\Twig_Node
+     * @return ConstantExpression|Node
      */
-    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env)
     {
-        if ($node instanceof \Twig_Node_Expression_Binary_Concat
-            && ($left = $node->getNode('left')) instanceof \Twig_Node_Expression_Constant
-            && ($right = $node->getNode('right')) instanceof \Twig_Node_Expression_Constant) {
-            return new \Twig_Node_Expression_Constant($left->getAttribute('value').$right->getAttribute('value'), $left->getTemplateLine());
+        if ($node instanceof ConcatBinary
+            && ($left = $node->getNode('left')) instanceof ConstantExpression
+            && ($right = $node->getNode('right')) instanceof ConstantExpression) {
+            return new ConstantExpression($left->getAttribute('value').$right->getAttribute('value'), $left->getTemplateLine());
         }
 
         return $node;

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -11,12 +11,17 @@
 
 namespace Translation\Bundle\Twig\Visitor;
 
+use Twig\Environment;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Node;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+
 /**
  * Removes translation metadata filters from the AST.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
+final class RemovingNodeVisitor extends AbstractNodeVisitor
 {
     /**
      * @var bool
@@ -32,14 +37,14 @@ final class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
     }
 
     /**
-     * @param \Twig_Node        $node
-     * @param \Twig_Environment $env
+     * @param Node        $node
+     * @param Environment $env
      *
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(Node $node, Environment $env)
     {
-        if ($this->enabled && $node instanceof \Twig_Node_Expression_Filter) {
+        if ($this->enabled && $node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
 
             if ('desc' === $name || 'meaning' === $name) {
@@ -51,12 +56,12 @@ final class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
     }
 
     /**
-     * @param \Twig_Node        $node
-     * @param \Twig_Environment $env
+     * @param Node        $node
+     * @param Environment $env
      *
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env)
     {
         return $node;
     }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-translation/symfony-storage": "^1.0",
         "php-translation/extractor": "^1.6",
         "nyholm/nsa": "^1.1",
-        "twig/twig": "<1.39 || ^2.0,<2.8"
+        "twig/twig": "^1.38,<1.39 || ^2.7,<2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2",


### PR DESCRIPTION
It's a following of https://github.com/php-translation/symfony-bundle/issues/288#issuecomment-472081268, since Twig 3 will remove non-namespaced classes.

---

EDIT: hum, there is a lot of Travis builds that fail: 
 - either because Composer ran out of memory (see #291)
 - either because deprecations make PHPUnit exit with status code different of 0, 
 - either because they are failing tests with `new_c` and `old_d` (which appears on other PRs too) :(