### PR TITLE
Fix delete obsolete translations command on non-interactive cli

### DIFF
--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -100,10 +100,12 @@ class DeleteObsoleteCommand extends Command
             return;
         }
 
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion(sprintf('You are about to remove %d translations. Do you wish to continue? (y/N) ', $messageCount), false);
-        if (!$helper->ask($input, $output, $question)) {
-            return;
+        if ($input->isInteractive()) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(sprintf('You are about to remove %d translations. Do you wish to continue? (y/N) ', $messageCount), false);
+            if (!$helper->ask($input, $output, $question)) {
+                return;
+            }
         }
 
         $progress = null;


### PR DESCRIPTION
Fixes the translationdelete-obsolete command not running in non-interactive shells. The question was simply never asked, not even when using 'yes'. This fix will run the command (assume yes) on non-interactive shells which allows you to run the command in scripts (e.g. update a lot of translations).