### PR TITLE
Tagged FormTypeHelp extractor

### DIFF
--- a/Resources/config/extractors.yml
+++ b/Resources/config/extractors.yml
@@ -36,6 +36,11 @@ services:
     tags:
       - { name: 'php_translation.visitor', type: 'php' }
 
+  php_translation.extractor.php.visitor.FormTypeHelp:
+    class: Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp
+    tags:
+      - { name: 'php_translation.visitor', type: 'php' }
+
   php_translation.extractor.php.visitor.FormTypeInvalidMessage:
     class: Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage
     tags:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
         "php-translation/common": "^1.0",
         "php-translation/symfony-storage": "^1.0",
-        "php-translation/extractor": "^1.3",
+        "php-translation/extractor": "^1.6",
         "nyholm/nsa": "^1.1",
         "twig/twig": "<1.39 || ^2.0,<2.8"
     },


### PR DESCRIPTION
The FormTypeHelp extractor (https://github.com/php-translation/extractor/pull/113) was not tagged as visitor, so was not used when launching **translation:extract** command.