### PR TITLE
[Js] Fix registering custom elements

### DIFF
--- a/Resources/public/js/editInPlace.js
+++ b/Resources/public/js/editInPlace.js
@@ -6,7 +6,17 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-document.registerElement('x-trans', { prototype: Object.create(HTMLElement.prototype) });
+(function () {
+    if (typeof customElements.define !== "undefined") {
+        customElements.define("x-trans", HTMLElement);
+
+        return;
+    }
+
+    document.registerElement("x-trans", {
+        prototype: Object.create(HTMLElement.prototype)
+    });
+})();
 
 /**
  * TranslationBundleEditInPlace boot the ContentTools editor and handle saves.


### PR DESCRIPTION
`document.registerElement()` doesn't exist anymore at least in Firefox. According to [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement), it has been replaced by [`customElements.define()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define).

Close #270 