### PR TITLE
An attempt to make all tests green again so we can moving forward and merge PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ matrix:
           # Test with lowest dependencies
         - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak" SYMFONY_PHPUNIT_VERSION="5.7"
-        - php: 5.5
+        - php: 5.6
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak" SYMFONY_PHPUNIT_VERSION="5.7"
 
           # Test the latest stable release
-        - php: 5.5
+        - php: 5.6
           env: SYMFONY_PHPUNIT_VERSION="5.7"
         - php: 5.6
           env: SYMFONY_PHPUNIT_VERSION="5.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         - php: 7.2
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
         - php: 7.0
-          env: DEPENDENCIES="dunglas/symfony-lock:^2 twig/twig:^1.34,<2.8 symfony/property-access:^2.8"
+          env: DEPENDENCIES="dunglas/symfony-lock:^2 twig/twig:^1.34,<1.39 symfony/property-access:^2.8"
 
           # Latest commit to master
         - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - TEST_COMMAND="composer test"
     - SYMFONY_PHPUNIT_VERSION="6.3"
+    - COMPOSER_MEMORY_LIMIT=-1
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         - php: 7.2
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
         - php: 7.0
-          env: DEPENDENCIES="dunglas/symfony-lock:^2 twig/twig:^1.34 symfony/property-access:^2.8"
+          env: DEPENDENCIES="dunglas/symfony-lock:^2 twig/twig:^1.34,<2.8 symfony/property-access:^2.8"
 
           # Latest commit to master
         - php: 7.2

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Translation\MessageCatalogue;
 use Translation\Bundle\Exception\MessageValidationException;

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Translation\MessageCatalogue;
 use Translation\Bundle\Exception\MessageValidationException;
@@ -250,7 +251,9 @@ class WebUIController extends Controller
     private function getLocale2LanguageMap()
     {
         $configuredLocales = $this->getParameter('php_translation.locales');
-        $names = Locales::getNames('en');
+        $names = class_exists(Locales::class)
+            ? Locales::getNames('en')
+            : Intl::getLocaleBundle()->getLocaleNames('en');
         $map = [];
         foreach ($configuredLocales as $l) {
             $map[$l] = isset($names[$l]) ? $names[$l] : $l;

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Locales;
 use Symfony\Component\Translation\MessageCatalogue;
 use Translation\Bundle\Exception\MessageValidationException;
 use Translation\Bundle\Service\StorageService;
@@ -250,7 +251,7 @@ class WebUIController extends Controller
     private function getLocale2LanguageMap()
     {
         $configuredLocales = $this->getParameter('php_translation.locales');
-        $names = Intl::getLocaleBundle()->getLocaleNames('en');
+        $names = Locales::getNames('en');
         $map = [];
         foreach ($configuredLocales as $l) {
             $map[$l] = isset($names[$l]) ? $names[$l] : $l;

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -30,6 +30,6 @@ abstract class BaseTwigTestCase extends TestCase
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
-        return $env->parse($env->tokenize(new \Twig_Source($content, null)))->getNode('body');
+        return $env->parse($env->tokenize(new \Twig_Source($content, '')))->getNode('body');
     }
 }

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -16,6 +16,7 @@ use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use Translation\Bundle\Twig\TranslationExtension;
+use Twig\Loader\ArrayLoader;
 
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -26,7 +27,7 @@ abstract class BaseTwigTestCase extends TestCase
     {
         $content = file_get_contents(__DIR__.'/Fixture/'.$file);
 
-        $env = new \Twig_Environment(new \Twig_Loader_Array([]));
+        $env = new \Twig_Environment(new ArrayLoader());
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -27,7 +27,10 @@ abstract class BaseTwigTestCase extends TestCase
     {
         $content = file_get_contents(__DIR__.'/Fixture/'.$file);
 
-        $env = new \Twig_Environment(new ArrayLoader());
+        $loader = class_exists(ArrayLoader::class)
+            ? new ArrayLoader()
+            : new \Twig_Loader_Array([]);
+        $env = new \Twig_Environment($loader);
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-translation/symfony-storage": "^1.0",
         "php-translation/extractor": "^1.3",
         "nyholm/nsa": "^1.1",
-        "twig/twig": "<2.8"
+        "twig/twig": "<1.39 || <2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.4 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-translation/symfony-storage": "^1.0",
         "php-translation/extractor": "^1.3",
         "nyholm/nsa": "^1.1",
-        "twig/twig": "<1.39 || <2.8"
+        "twig/twig": "<1.39 || ^2.0,<2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.4.19 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^5.5 || ^7.0",
         "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
         "symfony/validator": "^2.7 || ^3.0 || ^4.0",
-        "symfony/translation": "^2.7 || ^3.0 || ^4.0",
+        "symfony/translation": "^2.7 || ^3.0 || ^4.0,<4.2",
         "symfony/twig-bundle": "^2.7 || ^3.0 || ^4.0",
         "symfony/finder": "^2.7 || ^3.0 || ^4.0",
         "symfony/intl": "^2.7 || ^3.0 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "twig/twig": "<1.39 || <2.8"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.4 || ^4.0",
+        "symfony/phpunit-bridge": "^3.4.19 || ^4.0",
         "php-translation/translator": "^1.0",
         "php-http/curl-client": "^1.7",
         "php-http/message": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "symfony/templating": "^2.7 || ^3.0 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0",
         "symfony/web-profiler-bundle": "^2.7 || ^3.0 || ^4.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.2 || ^2.3",
-        "matthiasnoback/symfony-config-test": "^2.2 || ^3.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.2 || ^2.3 || ^3.0",
+        "matthiasnoback/symfony-config-test": "^2.2 || ^3.1 || ^4.0",
         "guzzlehttp/psr7": "^1.4",
         "nyholm/symfony-bundle-test": "^1.2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php-translation/common": "^1.0",
         "php-translation/symfony-storage": "^1.0",
         "php-translation/extractor": "^1.3",
-        "nyholm/nsa": "^1.1"
+        "nyholm/nsa": "^1.1",
+        "twig/twig": "<2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.4 || ^4.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
 
     <php>
         <env name="ENV" value="test" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=1" />
     </php>
 
     <formatter type="clover" usefile="false"/>


### PR DESCRIPTION
The current version of this bundle does not work with Symfony 4.2 well due to the new Intl formatter, that's why some tests failed. Other tests failed due to BC breaks and deprecations. Probably we should downgrade Sf Translation component version to `<4.2` before a proper fix to avoid BC breaks. Also, let's do not force failing builds on deprecation notices since this bundle is not actively developed lately - it causes more problems. Also, not sure, but it seems like TravisCI just dropped PHP 5.5 support, so I had to use PHP 5.6 as lowest PHP version