### PR TITLE
Don't prevent installing symfony/translation 4.2!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1",
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/validator": "^3.4 || ^4.0",
-        "symfony/translation": "^3.4 || ^4.0,<4.2",
+        "symfony/translation": "^3.4 || ^4.0",
         "symfony/twig-bundle": "^3.4 || ^4.0",
         "symfony/finder": "^3.4 || ^4.0",
         "symfony/intl": "^3.4 || ^4.0",


### PR DESCRIPTION
What a bad idea here, it almost the same as marking the bundle as abandoned...
4.2 is going to be EOLed in 5 days.