### PR TITLE
Added twig as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php-translation/common": "^1.0",
         "php-translation/symfony-storage": "^1.0",
         "php-translation/extractor": "^1.6",
-        "nyholm/nsa": "^1.1"
+        "nyholm/nsa": "^1.1",
+        "twig/twig": "^1.42 || ^2.11"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2",


### PR DESCRIPTION
Im not sure why we limited the versions in #313. But removing a direct dependency in #324 is not a good solution. 

I've added back `twig/twig` with their latest 1.x and 2.x versions. 