### PR TITLE
Replace (deprecated) `{% spaceless %}` and `{% for … if … %}` in Twig

### DIFF
--- a/Resources/views/SymfonyProfiler/translation.html.twig
+++ b/Resources/views/SymfonyProfiler/translation.html.twig
@@ -174,11 +174,11 @@
                     {{ message.translation }}
                 </td>
                 <td width="155px">
-                    {% spaceless %}
+                    {% apply spaceless %}
                     <a class="edit btn btn-sm" href="javascript:void(0);" onclick='getEditForm("{{ key }}")'>Edit</a>
                         |
                     <a class="sync btn btn-sm" href="javascript:void(0);" onclick='syncMessage("{{ key }}")'>Sync</a>
-                    {% endspaceless %}
+                    {% endapply %}
                 </td>
             </tr>
         {% endfor %}

--- a/Resources/views/WebUI/show.html.twig
+++ b/Resources/views/WebUI/show.html.twig
@@ -52,12 +52,12 @@
         {% endif %}
 
         <div id="new-translations"></div>
-        {% for idx, message in messages if message.new %}
+        {% for idx, message in messages|filter(message => message.new) %}
             {{ macro.printMessage(idx + 1, message, allow_delete, file_base_path) }}
         {% endfor %}
 
         {% set idxStart = messages|length %}
-        {% for idx, message in messages if not message.new %}
+        {% for idx, message in messages|filter(message => not message.new) %}
             {{ macro.printMessage(idx + idxStart, message, allow_delete, file_base_path) }}
         {% endfor %}
     </div>
@@ -98,7 +98,7 @@
         </div>
 
         <div class="col-md-6 col-12">
-            {% for locale,trans in message.otherTranslations if not trans is empty %}
+            {% for locale, trans in message.otherTranslations|filter(trans => not trans is empty) %}
                 <b>{{ locale }}</b>: {{ trans }}<br>
             {% endfor %}
         </div>


### PR DESCRIPTION
Since Twig 2.7, `{% spaceless %}` is deprecated, and will be removed in Twig 3.0.  This PR replaces it with `{% apply %}`. The result is one less deprecation notice. 

This PR also replaces the deprecated `{% for … if … %}` with `|filter(…)`.

See: https://twig.symfony.com/doc/2.x/deprecated.html