### PR TITLE
Add I/O type hinting, use null coalescing operator

### DIFF
--- a/Catalogue/CatalogueCounter.php
+++ b/Catalogue/CatalogueCounter.php
@@ -22,9 +22,6 @@ use Translation\Bundle\Model\Metadata;
  */
 class CatalogueCounter
 {
-    /**
-     * @return int
-     */
     public function getNumberOfDefinedMessages(MessageCatalogueInterface $catalogue): int
     {
         $total = 0;
@@ -35,9 +32,6 @@ class CatalogueCounter
         return $total;
     }
 
-    /**
-     * @return array
-     */
     public function getCatalogueStatistics(MessageCatalogueInterface $catalogue): array
     {
         $result = [];

--- a/Catalogue/CatalogueCounter.php
+++ b/Catalogue/CatalogueCounter.php
@@ -27,7 +27,7 @@ class CatalogueCounter
      *
      * @return int
      */
-    public function getNumberOfDefinedMessages(MessageCatalogueInterface $catalogue)
+    public function getNumberOfDefinedMessages(MessageCatalogueInterface $catalogue): int
     {
         $total = 0;
         foreach ($catalogue->getDomains() as $domain) {
@@ -42,7 +42,7 @@ class CatalogueCounter
      *
      * @return array
      */
-    public function getCatalogueStatistics(MessageCatalogueInterface $catalogue)
+    public function getCatalogueStatistics(MessageCatalogueInterface $catalogue): array
     {
         $result = [];
         $domains = $catalogue->getDomains();

--- a/Catalogue/CatalogueFetcher.php
+++ b/Catalogue/CatalogueFetcher.php
@@ -54,7 +54,7 @@ final class CatalogueFetcher
      *
      * @return MessageCatalogue[]
      */
-    public function getCatalogues(Configuration $config, array $locales = [])
+    public function getCatalogues(Configuration $config, array $locales = []): array
     {
         $dirs = $config->getPathsToTranslationFiles();
         if (empty($locales)) {
@@ -88,16 +88,16 @@ final class CatalogueFetcher
      *
      * @return bool
      */
-    private function isValidDomain(Configuration $config, $domain)
+    private function isValidDomain(Configuration $config, string $domain): bool
     {
         $blacklist = $config->getBlacklistDomains();
         $whitelist = $config->getWhitelistDomains();
 
-        if (!empty($blacklist) && \in_array($domain, $blacklist)) {
+        if (!empty($blacklist) && \in_array($domain, $blacklist, true)) {
             return false;
         }
 
-        if (!empty($whitelist) && !\in_array($domain, $whitelist)) {
+        if (!empty($whitelist) && !\in_array($domain, $whitelist, true)) {
             return false;
         }
 

--- a/Catalogue/CatalogueFetcher.php
+++ b/Catalogue/CatalogueFetcher.php
@@ -48,8 +48,6 @@ final class CatalogueFetcher
 
     /**
      * load any existing messages from the translation files.
-     *
-     * @return MessageCatalogue[]
      */
     public function getCatalogues(Configuration $config, array $locales = []): array
     {
@@ -80,11 +78,6 @@ final class CatalogueFetcher
         return $catalogues;
     }
 
-    /**
-     * @param string $domain
-     *
-     * @return bool
-     */
     private function isValidDomain(Configuration $config, string $domain): bool
     {
         $blacklist = $config->getBlacklistDomains();

--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -31,7 +31,7 @@ final class CatalogueManager
     /**
      * @param MessageCatalogueInterface[] $catalogues
      */
-    public function load(array $catalogues)
+    public function load(array $catalogues): void
     {
         $this->catalogues = [];
         foreach ($catalogues as $c) {
@@ -42,7 +42,7 @@ final class CatalogueManager
     /**
      * @return array
      */
-    public function getDomains()
+    public function getDomains(): array
     {
         /** @var MessageCatalogueInterface $c */
         $c = \reset($this->catalogues);
@@ -56,7 +56,7 @@ final class CatalogueManager
      *
      * @return CatalogueMessage[]
      */
-    public function getMessages($locale, $domain)
+    public function getMessages(string $locale, string $domain): array
     {
         $messages = [];
         if (!isset($this->catalogues[$locale])) {
@@ -82,12 +82,12 @@ final class CatalogueManager
      *
      * @return CatalogueMessage[]
      */
-    public function findMessages(array $config = [])
+    public function findMessages(array $config = []): array
     {
-        $inputDomain = isset($config['domain']) ? $config['domain'] : null;
-        $isNew = isset($config['isNew']) ? $config['isNew'] : null;
-        $isObsolete = isset($config['isObsolete']) ? $config['isObsolete'] : null;
-        $isApproved = isset($config['isApproved']) ? $config['isApproved'] : null;
+        $inputDomain = $config['domain'] ?? null;
+        $isNew = $config['isNew'] ?? null;
+        $isObsolete = $config['isObsolete'] ?? null;
+        $isApproved = $config['isApproved'] ?? null;
 
         $messages = [];
         $catalogues = [];
@@ -112,7 +112,7 @@ final class CatalogueManager
             }
         }
 
-        $messages = \array_filter($messages, function (CatalogueMessage $m) use ($isNew, $isObsolete, $isApproved) {
+        $messages = \array_filter($messages, static function (CatalogueMessage $m) use ($isNew, $isObsolete, $isApproved) {
             if (null !== $isNew && $m->isNew() !== $isNew) {
                 return false;
             }
@@ -156,7 +156,7 @@ final class CatalogueManager
      *
      * @return CatalogueMessage
      */
-    private function createMessage(MessageCatalogueInterface $catalogue, $locale, $domain, $key, $text)
+    private function createMessage(MessageCatalogueInterface $catalogue, $locale, $domain, $key, $text): CatalogueMessage
     {
         $catalogueMessage = new CatalogueMessage($this, $locale, $domain, $key, $text);
 

--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -26,7 +26,7 @@ final class CatalogueManager
     /**
      * @var MessageCatalogueInterface[]
      */
-    private $catalogues;
+    private $catalogues = [];
 
     /**
      * @param MessageCatalogueInterface[] $catalogues

--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -39,9 +39,6 @@ final class CatalogueManager
         }
     }
 
-    /**
-     * @return array
-     */
     public function getDomains(): array
     {
         /** @var MessageCatalogueInterface $c */
@@ -51,9 +48,6 @@ final class CatalogueManager
     }
 
     /**
-     * @param string $locale
-     * @param string $domain
-     *
      * @return CatalogueMessage[]
      */
     public function getMessages(string $locale, string $domain): array
@@ -132,10 +126,8 @@ final class CatalogueManager
     /**
      * @param string $domain
      * @param string $key
-     *
-     * @return array
      */
-    public function getTranslations($domain, $key)
+    public function getTranslations($domain, $key): array
     {
         $translations = [];
         foreach ($this->catalogues as $locale => $catalogue) {
@@ -147,14 +139,6 @@ final class CatalogueManager
         return $translations;
     }
 
-    /**
-     * @param $locale
-     * @param $domain
-     * @param $key
-     * @param $text
-     *
-     * @return CatalogueMessage
-     */
     private function createMessage(MessageCatalogueInterface $catalogue, string $locale, string $domain, string $key, string $text): CatalogueMessage
     {
         $catalogueMessage = new CatalogueMessage($this, $locale, $domain, $key, $text);

--- a/Catalogue/CatalogueWriter.php
+++ b/Catalogue/CatalogueWriter.php
@@ -36,10 +36,7 @@ final class CatalogueWriter
      */
     private $defaultLocale;
 
-    /**
-     * @param string $defaultLocale
-     */
-    public function __construct(TranslationWriter $writer, $defaultLocale)
+    public function __construct(TranslationWriter $writer, string $defaultLocale)
     {
         if (!$writer instanceof TranslationWriterInterface) {
             $writer = new LegacyTranslationWriter($writer);

--- a/Catalogue/CatalogueWriter.php
+++ b/Catalogue/CatalogueWriter.php
@@ -54,7 +54,7 @@ final class CatalogueWriter
      * @param Configuration      $config
      * @param MessageCatalogue[] $catalogues
      */
-    public function writeCatalogues(Configuration $config, array $catalogues)
+    public function writeCatalogues(Configuration $config, array $catalogues): void
     {
         foreach ($catalogues as $catalogue) {
             $this->writer->write(

--- a/Catalogue/Operation/ReplaceOperation.php
+++ b/Catalogue/Operation/ReplaceOperation.php
@@ -30,7 +30,7 @@ use Symfony\Component\Translation\MetadataAwareInterface;
  */
 final class ReplaceOperation extends AbstractOperation
 {
-    protected function processDomain($domain)
+    protected function processDomain($domain): void
     {
         $this->messages[$domain] = [
             'all' => [],
@@ -114,7 +114,7 @@ final class ReplaceOperation extends AbstractOperation
      *
      * @return array
      */
-    private function mergeMetadata($source, $target)
+    private function mergeMetadata(?array $source, ?array $target): array
     {
         if (empty($source) && empty($target)) {
             return [];
@@ -132,12 +132,10 @@ final class ReplaceOperation extends AbstractOperation
             return $source;
         }
 
-        $result = $this->doMergeMetadata($source, $target);
-
-        return $result;
+        return $this->doMergeMetadata($source, $target);
     }
 
-    private function doMergeMetadata(array $source, array $target)
+    private function doMergeMetadata(array $source, array $target): array
     {
         $isTargetArrayAssociative = $this->isArrayAssociative($target);
         foreach ($target as $key => $value) {
@@ -153,7 +151,7 @@ final class ReplaceOperation extends AbstractOperation
                     $source[$key] = $value;
                 }
                 // if sequential
-            } elseif (!\in_array($value, $source)) {
+            } elseif (!\in_array($value, $source, true)) {
                 $source[] = $value;
             }
         }
@@ -161,7 +159,7 @@ final class ReplaceOperation extends AbstractOperation
         return $source;
     }
 
-    public function isArrayAssociative(array $arr)
+    public function isArrayAssociative(array $arr): bool
     {
         if ([] === $arr) {
             return false;

--- a/Catalogue/Operation/ReplaceOperation.php
+++ b/Catalogue/Operation/ReplaceOperation.php
@@ -97,8 +97,7 @@ final class ReplaceOperation extends AbstractOperation
 
     /**
      * @param MessageCatalogueInterface|MetadataAwareInterface $catalogue
-     * @param string $domain
-     * @param string $key
+     *
      * @return array|string|mixed|null Can return anything..
      */
     private function getMetadata($catalogue, string $domain, string $key = '')
@@ -110,12 +109,6 @@ final class ReplaceOperation extends AbstractOperation
         return $catalogue->getMetadata($key, $domain);
     }
 
-    /**
-     * @param array|null $source
-     * @param array|null $target
-     *
-     * @return array
-     */
     private function mergeMetadata(?array $source, ?array $target): array
     {
         if (empty($source) && empty($target)) {

--- a/Command/BundleTrait.php
+++ b/Command/BundleTrait.php
@@ -20,7 +20,7 @@ trait BundleTrait
     private function configureBundleDirs(InputInterface $input, Configuration $config): void
     {
         if ($bundleName = $input->getOption('bundle')) {
-            if (strpos($bundleName, '@') === 0) {
+            if (0 === \strpos($bundleName, '@')) {
                 if (false === $pos = \strpos($bundleName, '/')) {
                     $bundleName = \substr($bundleName, 1);
                 } else {

--- a/Command/BundleTrait.php
+++ b/Command/BundleTrait.php
@@ -17,7 +17,7 @@ use Translation\Bundle\Model\Configuration;
 
 trait BundleTrait
 {
-    private function configureBundleDirs(InputInterface $input, Configuration $config)
+    private function configureBundleDirs(InputInterface $input, Configuration $config): void
     {
         if ($bundleName = $input->getOption('bundle')) {
             if ('@' === $bundleName[0]) {

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -67,7 +67,7 @@ class DeleteObsoleteCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::$defaultName)
@@ -78,7 +78,7 @@ class DeleteObsoleteCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $configName = $input->getArgument('configuration');
         $locales = [];
@@ -86,7 +86,10 @@ class DeleteObsoleteCommand extends Command
             $locales = [$inputLocale];
         }
 
-        $config = $this->configurationManager->getConfiguration($configName);
+        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
+            return;
+        }
+
         $this->configureBundleDirs($input, $config);
         $this->catalogueManager->load($this->catalogueFetcher->getCatalogues($config, $locales));
 

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -87,7 +87,7 @@ class DeleteObsoleteCommand extends Command
         }
 
         if (null === $config = $this->configurationManager->getConfiguration($configName)) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
         }
 
         $this->configureBundleDirs($input, $config);

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -89,8 +89,6 @@ class DownloadCommand extends Command
     }
 
     /**
-     * @param string $directory
-     *
      * @return bool|string
      */
     private function hashDirectory(string $directory)

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -74,7 +74,7 @@ class DownloadCommand extends Command
         $storage = $this->getStorage($configName);
 
         if (null === $configuration = $this->configurationManager->getConfiguration($configName)) {
-            return;
+            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
         }
 
         $this->configureBundleDirs($input, $configuration);

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -57,7 +57,7 @@ class DownloadCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::$defaultName)
@@ -68,11 +68,14 @@ class DownloadCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $configName = $input->getArgument('configuration');
         $storage = $this->getStorage($configName);
-        $configuration = $this->configurationManager->getConfiguration($configName);
+
+        if (null === $configuration = $this->configurationManager->getConfiguration($configName)) {
+            return;
+        }
 
         $this->configureBundleDirs($input, $configuration);
 
@@ -90,7 +93,12 @@ class DownloadCommand extends Command
         }
     }
 
-    private function hashDirectory($directory)
+    /**
+     * @param string $directory
+     *
+     * @return bool|string
+     */
+    private function hashDirectory(string $directory)
     {
         if (!\is_dir($directory)) {
             return false;

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -136,9 +136,6 @@ class ExtractCommand extends Command
         }
     }
 
-    /**
-     * @return Finder
-     */
     private function getConfiguredFinder(Configuration $config): Finder
     {
         $finder = new Finder();

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -83,7 +83,7 @@ class ExtractCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::$defaultName)
@@ -95,9 +95,11 @@ class ExtractCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'));
+        if (null === $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'))) {
+            return;
+        }
 
         $locales = [];
         if ($inputLocale = $input->getArgument('locale')) {
@@ -145,7 +147,7 @@ class ExtractCommand extends Command
      *
      * @return Finder
      */
-    private function getConfiguredFinder(Configuration $config)
+    private function getConfiguredFinder(Configuration $config): Finder
     {
         $finder = new Finder();
         $finder->in($config->getDirs());

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -97,8 +97,9 @@ class ExtractCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        if (null === $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'))) {
-            return;
+        $configName = $input->getArgument('configuration');
+        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
+            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
         }
 
         $locales = [];

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -62,7 +62,7 @@ class StatusCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::$defaultName)
@@ -74,9 +74,12 @@ class StatusCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'));
+        if (null === $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'))) {
+            return;
+        }
+
         $this->configureBundleDirs($input, $config);
 
         $locales = [];

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -76,8 +76,9 @@ class StatusCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        if (null === $config = $this->configurationManager->getConfiguration($input->getArgument('configuration'))) {
-            return;
+        $configName = $input->getArgument('configuration');
+        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
+            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
         }
 
         $this->configureBundleDirs($input, $config);

--- a/Command/StorageTrait.php
+++ b/Command/StorageTrait.php
@@ -24,8 +24,6 @@ trait StorageTrait
     /**
      * @param string|string[]|null $configName
      *
-     * @return \Translation\Bundle\Service\StorageService
-     *
      * @throws \InvalidArgumentException
      */
     private function getStorage($configName): StorageService

--- a/Command/StorageTrait.php
+++ b/Command/StorageTrait.php
@@ -12,6 +12,7 @@
 namespace Translation\Bundle\Command;
 
 use Translation\Bundle\Service\StorageManager;
+use Translation\Bundle\Service\StorageService;
 
 trait StorageTrait
 {
@@ -21,13 +22,13 @@ trait StorageTrait
     private $storageManager;
 
     /**
-     * @param string $configName
+     * @param string|string[]|null $configName
      *
      * @return \Translation\Bundle\Service\StorageService
      *
      * @throws \InvalidArgumentException
      */
-    private function getStorage($configName)
+    private function getStorage($configName): StorageService
     {
         if (null === $storage = $this->storageManager->getStorage($configName)) {
             $availableStorages = $this->storageManager->getNames();

--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -37,7 +37,7 @@ class SyncCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::$defaultName)
@@ -46,7 +46,7 @@ class SyncCommand extends Command
             ->addArgument('direction', InputArgument::OPTIONAL, 'Use "down" if local changes should be overwritten, otherwise "up"', 'down');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         switch ($input->getArgument('direction')) {
             case 'down':

--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -31,7 +31,7 @@ class EditInPlaceController extends Controller
      *
      * @return Response
      */
-    public function editAction(Request $request, $configName, $locale)
+    public function editAction(Request $request, string $configName, string $locale): Response
     {
         try {
             $messages = $this->getMessages($request, $locale, ['Edit']);
@@ -62,7 +62,7 @@ class EditInPlaceController extends Controller
      *
      * @throws MessageValidationException
      */
-    private function getMessages(Request $request, $locale, array $validationGroups = [])
+    private function getMessages(Request $request, string $locale, array $validationGroups = []): array
     {
         $json = $request->getContent();
         $data = \json_decode($json, true);

--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -24,12 +24,6 @@ use Translation\Common\Model\MessageInterface;
  */
 class EditInPlaceController extends Controller
 {
-    /**
-     * @param string $configName
-     * @param string $locale
-     *
-     * @return Response
-     */
     public function editAction(Request $request, string $configName, string $locale): Response
     {
         try {
@@ -53,8 +47,6 @@ class EditInPlaceController extends Controller
     /**
      * Get and validate messages from the request.
      *
-     * @param string $locale
-     *
      * @return MessageInterface[]
      *
      * @throws MessageValidationException
@@ -67,7 +59,7 @@ class EditInPlaceController extends Controller
         $validator = $this->get('validator');
 
         foreach ($data as $key => $value) {
-            list($domain, $translationKey) = \explode('|', $key);
+            [$domain, $translationKey] = \explode('|', $key);
 
             $message = new Message($translationKey, $domain, $locale, $value);
 

--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -25,11 +25,6 @@ use Translation\Common\Model\MessageInterface;
  */
 class SymfonyProfilerController extends Controller
 {
-    /**
-     * @param string $token
-     *
-     * @return Response
-     */
     public function editAction(Request $request, string $token): Response
     {
         if (!$this->getParameter('php_translation.toolbar.allow_edit')) {
@@ -60,11 +55,6 @@ class SymfonyProfilerController extends Controller
         return new Response($message->getTranslation());
     }
 
-    /**
-     * @param string $token
-     *
-     * @return Response
-     */
     public function syncAction(Request $request, string $token): Response
     {
         if (!$request->isXmlHttpRequest()) {
@@ -84,8 +74,6 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param $token
-     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function syncAllAction(Request $request, string $token): Response
@@ -105,10 +93,6 @@ class SymfonyProfilerController extends Controller
      * Save the selected translation to resources.
      *
      * @author Damien Alexandre (damienalexandre)
-     *
-     * @param string $token
-     *
-     * @return Response
      */
     public function createAssetsAction(Request $request, string $token): Response
     {
@@ -132,11 +116,6 @@ class SymfonyProfilerController extends Controller
         return new Response(\sprintf('%s new assets created!', \count($uploaded)));
     }
 
-    /**
-     * @param string $token
-     *
-     * @return SfProfilerMessage
-     */
     private function getMessage(Request $request, string $token): SfProfilerMessage
     {
         $profiler = $this->get('profiler');
@@ -169,8 +148,6 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param string $token
-     *
      * @return MessageInterface[]
      */
     protected function getSelectedMessages(Request $request, string $token): array

--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -31,7 +31,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return Response
      */
-    public function editAction(Request $request, $token)
+    public function editAction(Request $request, string $token): Response
     {
         if (!$this->getParameter('php_translation.toolbar.allow_edit')) {
             return new Response('You are not allowed to edit the translations.');
@@ -67,7 +67,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return Response
      */
-    public function syncAction(Request $request, $token)
+    public function syncAction(Request $request, string $token): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return $this->redirectToRoute('_profiler', ['token' => $token]);
@@ -91,7 +91,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function syncAllAction(Request $request, $token)
+    public function syncAllAction(Request $request, string $token): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return $this->redirectToRoute('_profiler', ['token' => $token]);
@@ -114,7 +114,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return Response
      */
-    public function createAssetsAction(Request $request, $token)
+    public function createAssetsAction(Request $request, string $token): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return $this->redirectToRoute('_profiler', ['token' => $token]);
@@ -142,7 +142,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return SfProfilerMessage
      */
-    private function getMessage(Request $request, $token)
+    private function getMessage(Request $request, string $token): SfProfilerMessage
     {
         $profiler = $this->get('profiler');
         $profiler->disable();
@@ -179,7 +179,7 @@ class SymfonyProfilerController extends Controller
      *
      * @return MessageInterface[]
      */
-    protected function getSelectedMessages(Request $request, $token)
+    protected function getSelectedMessages(Request $request, string $token): array
     {
         $profiler = $this->get('profiler');
         $profiler->disable();

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -32,10 +32,6 @@ class WebUIController extends Controller
 {
     /**
      * Show a dashboard for the configuration.
-     *
-     * @param string|null $configName
-     *
-     * @return Response
      */
     public function indexAction(?string $configName = null): Response
     {
@@ -85,12 +81,6 @@ class WebUIController extends Controller
 
     /**
      * Show a catalogue.
-     *
-     * @param string $configName
-     * @param string $locale
-     * @param string $domain
-     *
-     * @return Response
      */
     public function showAction(string $configName, string $locale, string $domain): Response
     {
@@ -124,14 +114,7 @@ class WebUIController extends Controller
         ]);
     }
 
-    /**
-     * @param string $configName
-     * @param string $locale
-     * @param string $domain
-     *
-     * @return Response
-     */
-    public function createAction(Request $request, string $configName, string $locale, string $domain)
+    public function createAction(Request $request, string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled') || !$this->getParameter('php_translation.webui.allow_create')) {
             return new Response('You are not allowed to create. Check you config. ', 400);
@@ -160,13 +143,6 @@ class WebUIController extends Controller
         ]);
     }
 
-    /**
-     * @param string $configName
-     * @param string $locale
-     * @param string $domain
-     *
-     * @return Response
-     */
     public function editAction(Request $request, string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled')) {
@@ -189,13 +165,6 @@ class WebUIController extends Controller
         return new Response('Translation updated');
     }
 
-    /**
-     * @param string $configName
-     * @param string $locale
-     * @param string $domain
-     *
-     * @return Response
-     */
     public function deleteAction(Request $request, string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled') || !$this->getParameter('php_translation.webui.allow_delete')) {
@@ -218,9 +187,6 @@ class WebUIController extends Controller
         return new Response('Message was deleted');
     }
 
-    /**
-     * @return MessageInterface
-     */
     private function getMessageFromRequest(Request $request): Message
     {
         $json = $request->getContent();

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -37,7 +37,7 @@ class WebUIController extends Controller
      *
      * @return Response
      */
-    public function indexAction($configName = null)
+    public function indexAction(?string $configName = null): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled')) {
             return new Response('You are not allowed here. Check you config. ', 400);
@@ -92,7 +92,7 @@ class WebUIController extends Controller
      *
      * @return Response
      */
-    public function showAction($configName, $locale, $domain)
+    public function showAction(string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled')) {
             return new Response('You are not allowed here. Check you config. ', 400);
@@ -132,7 +132,7 @@ class WebUIController extends Controller
      *
      * @return Response
      */
-    public function createAction(Request $request, $configName, $locale, $domain)
+    public function createAction(Request $request, string $configName, string $locale, string $domain)
     {
         if (!$this->getParameter('php_translation.webui.enabled') || !$this->getParameter('php_translation.webui.allow_create')) {
             return new Response('You are not allowed to create. Check you config. ', 400);
@@ -174,7 +174,7 @@ class WebUIController extends Controller
      *
      * @return Response
      */
-    public function editAction(Request $request, $configName, $locale, $domain)
+    public function editAction(Request $request, string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled')) {
             return new Response('You are not allowed here. Check you config. ', 400);
@@ -204,7 +204,7 @@ class WebUIController extends Controller
      *
      * @return Response
      */
-    public function deleteAction(Request $request, $configName, $locale, $domain)
+    public function deleteAction(Request $request, string $configName, string $locale, string $domain): Response
     {
         if (!$this->getParameter('php_translation.webui.enabled') || !$this->getParameter('php_translation.webui.allow_delete')) {
             return new Response('You are not allowed to create. Check you config. ', 400);
@@ -231,7 +231,7 @@ class WebUIController extends Controller
      *
      * @return MessageInterface
      */
-    private function getMessageFromRequest(Request $request)
+    private function getMessageFromRequest(Request $request): MessageInterface
     {
         $json = $request->getContent();
         $data = \json_decode($json, true);
@@ -248,7 +248,7 @@ class WebUIController extends Controller
      *
      * @return array locale => language
      */
-    private function getLocale2LanguageMap()
+    private function getLocale2LanguageMap(): array
     {
         $configuredLocales = $this->getParameter('php_translation.locales');
         $names = \class_exists(Locales::class)
@@ -256,7 +256,7 @@ class WebUIController extends Controller
             : Intl::getLocaleBundle()->getLocaleNames('en');
         $map = [];
         foreach ($configuredLocales as $l) {
-            $map[$l] = isset($names[$l]) ? $names[$l] : $l;
+            $map[$l] = $names[$l] ?? $l;
         }
 
         return $map;
@@ -268,7 +268,7 @@ class WebUIController extends Controller
      *
      * @throws MessageValidationException
      */
-    private function validateMessage(MessageInterface $message, array $validationGroups)
+    private function validateMessage(MessageInterface $message, array $validationGroups): void
     {
         $errors = $this->get('validator')->validate($message, null, $validationGroups);
         if (\count($errors) > 0) {

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -229,9 +229,9 @@ class WebUIController extends Controller
     /**
      * @param Request $request
      *
-     * @return MessageInterface
+     * @return \Translation\Common\Model\Message
      */
-    private function getMessageFromRequest(Request $request): MessageInterface
+    private function getMessageFromRequest(Request $request): Message
     {
         $json = $request->getContent();
         $data = \json_decode($json, true);

--- a/DependencyInjection/CompilerPass/EditInPlacePass.php
+++ b/DependencyInjection/CompilerPass/EditInPlacePass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class EditInPlacePass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         /* @var Definition $def */
         if (!$container->hasDefinition('php_translator.edit_in_place.xtrans_html_translator')) {

--- a/DependencyInjection/CompilerPass/ExternalTranslatorPass.php
+++ b/DependencyInjection/CompilerPass/ExternalTranslatorPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ExternalTranslatorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         /* @var Definition $def */
         if (!$container->hasDefinition('php_translation.translator_service.external_translator')) {

--- a/DependencyInjection/CompilerPass/ExtractorPass.php
+++ b/DependencyInjection/CompilerPass/ExtractorPass.php
@@ -54,9 +54,6 @@ class ExtractorPass implements CompilerPassInterface
         return $extractors;
     }
 
-    /**
-     * @param $extractors
-     */
     private function addVisitors(ContainerBuilder $container, array $extractors): void
     {
         $services = $container->findTaggedServiceIds('php_translation.visitor');

--- a/DependencyInjection/CompilerPass/ExtractorPass.php
+++ b/DependencyInjection/CompilerPass/ExtractorPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ExtractorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $extractors = $this->getExtractors($container);
         $this->addVisitors($container, $extractors);
@@ -32,7 +32,7 @@ class ExtractorPass implements CompilerPassInterface
      *
      * @return array type => Definition[]
      */
-    private function getExtractors(ContainerBuilder $container)
+    private function getExtractors(ContainerBuilder $container): array
     {
         if (!$container->hasDefinition('php_translation.extractor')) {
             return [];
@@ -60,7 +60,7 @@ class ExtractorPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param $extractors
      */
-    private function addVisitors(ContainerBuilder $container, $extractors)
+    private function addVisitors(ContainerBuilder $container, array $extractors): void
     {
         $services = $container->findTaggedServiceIds('php_translation.visitor');
         foreach ($services as $id => $tags) {

--- a/DependencyInjection/CompilerPass/FileDumperBackupPass.php
+++ b/DependencyInjection/CompilerPass/FileDumperBackupPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class FileDumperBackupPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (Kernel::MAJOR_VERSION >= 4) {
             return;

--- a/DependencyInjection/CompilerPass/LoaderOrReaderPass.php
+++ b/DependencyInjection/CompilerPass/LoaderOrReaderPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class LoaderOrReaderPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->has('translation.reader')) {
             $container->setAlias('translation.loader_or_reader', 'translation.reader');

--- a/DependencyInjection/CompilerPass/StoragePass.php
+++ b/DependencyInjection/CompilerPass/StoragePass.php
@@ -57,9 +57,6 @@ class StoragePass implements CompilerPassInterface
         }
     }
 
-    /**
-     * @return Definition
-     */
     private function getDefinition(ContainerBuilder $container, string $name): Definition
     {
         if (!isset($this->definitions[$name])) {

--- a/DependencyInjection/CompilerPass/StoragePass.php
+++ b/DependencyInjection/CompilerPass/StoragePass.php
@@ -28,7 +28,7 @@ class StoragePass implements CompilerPassInterface
      */
     private $definitions;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $services = $container->findTaggedServiceIds('php_translation.storage');
         foreach ($services as $id => $tags) {
@@ -59,10 +59,11 @@ class StoragePass implements CompilerPassInterface
 
     /**
      * @param ContainerBuilder $container
+     * @param string           $name
      *
      * @return Definition
      */
-    private function getDefinition(ContainerBuilder $container, $name)
+    private function getDefinition(ContainerBuilder $container, string $name): Definition
     {
         if (!isset($this->definitions[$name])) {
             $this->definitions[$name] = $container->getDefinition('php_translation.storage.'.$name);

--- a/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
+++ b/DependencyInjection/CompilerPass/SymfonyProfilerPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class SymfonyProfilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         /* @var Definition $def */
         if (!$container->hasDefinition('php_translation.data_collector')) {

--- a/DependencyInjection/CompilerPass/ValidatorVisitorPass.php
+++ b/DependencyInjection/CompilerPass/ValidatorVisitorPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ValidatorVisitorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('validator')) {
             return;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('translation');
         // Keep compatibility with symfony/config < 4.2
@@ -90,7 +90,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $root
      */
-    private function configsNode(ArrayNodeDefinition $root)
+    private function configsNode(ArrayNodeDefinition $root): void
     {
         $container = $this->container;
         $root->children()
@@ -181,7 +181,7 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
-    private function addAutoTranslateNode(ArrayNodeDefinition $root)
+    private function addAutoTranslateNode(ArrayNodeDefinition $root): void
     {
         $root->children()
             ->arrayNode('fallback_translation')
@@ -194,7 +194,7 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
-    private function addEditInPlaceNode(ArrayNodeDefinition $root)
+    private function addEditInPlaceNode(ArrayNodeDefinition $root): void
     {
         $root->children()
             ->arrayNode('edit_in_place')
@@ -208,7 +208,7 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
-    private function addWebUINode(ArrayNodeDefinition $root)
+    private function addWebUINode(ArrayNodeDefinition $root): void
     {
         $root->children()
             ->arrayNode('webui')

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -226,8 +226,6 @@ class TranslationExtension extends Extension
     /**
      * To avoid BC break for Symfony 3.3+.
      *
-     * @param string $parent
-     *
      * @return ChildDefinition|DefinitionDecorator
      */
     private function createChildDefinition(string $parent)

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -33,7 +33,7 @@ class TranslationExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration($container);
         $config = $this->processConfiguration($configuration, $configs);
@@ -47,7 +47,8 @@ class TranslationExtension extends Extension
             ->addMethodCall('setSymfonyMajorVersion', [Kernel::MAJOR_VERSION]);
 
         $container->setParameter('php_translation.locales', $config['locales']);
-        $container->setParameter('php_translation.default_locale', isset($config['default_locale']) ? $config['default_locale'] : $container->getParameter('kernel.default_locale'));
+        $container->setParameter('php_translation.default_locale',
+            $config['default_locale'] ?? $container->getParameter('kernel.default_locale'));
         $this->handleConfigNode($container, $config);
 
         if ($config['webui']['enabled']) {
@@ -90,7 +91,7 @@ class TranslationExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    private function handleConfigNode(ContainerBuilder $container, array $config)
+    private function handleConfigNode(ContainerBuilder $container, array $config): void
     {
         $storageManager = $container->getDefinition('php_translation.storage_manager');
         $configurationManager = $container->getDefinition('php_translation.configuration_manager');
@@ -155,7 +156,7 @@ class TranslationExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    private function enableWebUi(ContainerBuilder $container, array $config)
+    private function enableWebUi(ContainerBuilder $container, array $config): void
     {
         $container->setParameter('php_translation.webui.enabled', true);
         $container->setParameter('php_translation.webui.allow_create', $config['webui']['allow_create']);
@@ -179,7 +180,7 @@ class TranslationExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    private function enableEditInPlace(ContainerBuilder $container, array $config)
+    private function enableEditInPlace(ContainerBuilder $container, array $config): void
     {
         $name = $config['edit_in_place']['config_name'];
 
@@ -207,7 +208,7 @@ class TranslationExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    private function enableSymfonyProfiler(ContainerBuilder $container, array $config)
+    private function enableSymfonyProfiler(ContainerBuilder $container, array $config): void
     {
         $container->setParameter('php_translation.toolbar.allow_edit', $config['symfony_profiler']['allow_edit']);
     }
@@ -218,7 +219,7 @@ class TranslationExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    private function enableFallbackAutoTranslator(ContainerBuilder $container, array $config)
+    private function enableFallbackAutoTranslator(ContainerBuilder $container, array $config): void
     {
         $externalTranslatorId = 'php_translation.translator_service.'.$config['fallback_translation']['service'];
         $externalTranslatorDef = $container->getDefinition($externalTranslatorId);
@@ -232,7 +233,7 @@ class TranslationExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'translation';
     }
@@ -246,7 +247,7 @@ class TranslationExtension extends Extension
      */
     private function createChildDefinition($parent)
     {
-        if (\class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
+        if (\class_exists(ChildDefinition::class)) {
             return new ChildDefinition($parent);
         }
 
@@ -256,7 +257,7 @@ class TranslationExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container);
     }

--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -36,7 +36,7 @@ final class Activator implements ActivatorInterface
     /**
      * Enable the Edit In Place mode.
      */
-    public function activate()
+    public function activate(): void
     {
         $this->session->set(self::KEY, true);
     }
@@ -44,7 +44,7 @@ final class Activator implements ActivatorInterface
     /**
      * Disable the Edit In Place mode.
      */
-    public function deactivate()
+    public function deactivate(): void
     {
         $this->session->remove(self::KEY);
     }
@@ -52,7 +52,7 @@ final class Activator implements ActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function checkRequest(Request $request = null)
+    public function checkRequest(Request $request = null): bool
     {
         if (!$this->session->has(self::KEY)) {
             return false;

--- a/EditInPlace/ActivatorInterface.php
+++ b/EditInPlace/ActivatorInterface.php
@@ -20,8 +20,6 @@ interface ActivatorInterface
 {
     /**
      * Tells if the Edit In Place mode is enabled for this request.
-     *
-     * @return bool
      */
     public function checkRequest(Request $request = null): bool;
 }

--- a/EditInPlace/ActivatorInterface.php
+++ b/EditInPlace/ActivatorInterface.php
@@ -25,5 +25,5 @@ interface ActivatorInterface
      *
      * @return bool
      */
-    public function checkRequest(Request $request = null);
+    public function checkRequest(Request $request = null): bool;
 }

--- a/EventListener/AutoAddMissingTranslations.php
+++ b/EventListener/AutoAddMissingTranslations.php
@@ -41,7 +41,7 @@ final class AutoAddMissingTranslations
         $this->storage = $storage;
     }
 
-    public function onTerminate(Event $event)
+    public function onTerminate(Event $event): void
     {
         if (null === $this->dataCollector) {
             return;

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -65,7 +65,7 @@ HTML;
      */
     private $showUntranslatable;
 
-    public function __construct(ActivatorInterface $activator, UrlGeneratorInterface $router, Packages $packages, $configName = 'default', $showUntranslatable = true)
+    public function __construct(ActivatorInterface $activator, UrlGeneratorInterface $router, Packages $packages, string $configName = 'default', bool $showUntranslatable = true)
     {
         $this->activator = $activator;
         $this->router = $router;
@@ -74,7 +74,7 @@ HTML;
         $this->showUntranslatable = $showUntranslatable;
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/Model/CatalogueMessage.php
+++ b/Model/CatalogueMessage.php
@@ -50,12 +50,6 @@ final class CatalogueMessage
      */
     private $metadata;
 
-    /**
-     * @param string $locale
-     * @param string $domain
-     * @param string $key
-     * @param string $message
-     */
     public function __construct(CatalogueManager $catalogueManager, string $locale, string $domain, string $key, string $message)
     {
         $this->catalogueManager = $catalogueManager;
@@ -65,9 +59,6 @@ final class CatalogueMessage
         $this->message = $message;
     }
 
-    /**
-     * @param Metadata $metadata
-     */
     public function setMetadata(Metadata $metadata): void
     {
         $this->metadata = $metadata;
@@ -78,33 +69,21 @@ final class CatalogueMessage
         return $this->getMessage();
     }
 
-    /**
-     * @return string
-     */
     public function getKey(): string
     {
         return $this->key;
     }
 
-    /**
-     * @return string
-     */
     public function getDomain(): string
     {
         return $this->domain;
     }
 
-    /**
-     * @return string
-     */
     public function getLocale(): string
     {
         return $this->locale;
     }
 
-    /**
-     * @return string
-     */
     public function getMessage(): string
     {
         return $this->message;

--- a/Model/CatalogueMessage.php
+++ b/Model/CatalogueMessage.php
@@ -57,7 +57,7 @@ final class CatalogueMessage
      * @param string           $key
      * @param string           $message
      */
-    public function __construct(CatalogueManager $catalogueManager, $locale, $domain, $key, $message)
+    public function __construct(CatalogueManager $catalogueManager, string $locale, string $domain, string $key, string $message)
     {
         $this->catalogueManager = $catalogueManager;
         $this->locale = $locale;
@@ -69,12 +69,12 @@ final class CatalogueMessage
     /**
      * @param Metadata|null $metadata
      */
-    public function setMetadata(Metadata $metadata)
+    public function setMetadata(?Metadata $metadata)
     {
         $this->metadata = $metadata;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getMessage();
     }
@@ -82,7 +82,7 @@ final class CatalogueMessage
     /**
      * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -90,7 +90,7 @@ final class CatalogueMessage
     /**
      * @return string
      */
-    public function getDomain()
+    public function getDomain(): string
     {
         return $this->domain;
     }
@@ -98,7 +98,7 @@ final class CatalogueMessage
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
@@ -106,12 +106,12 @@ final class CatalogueMessage
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    public function getOtherTranslations()
+    public function getOtherTranslations(): array
     {
         $translations = $this->catalogueManager->getTranslations($this->domain, $this->getKey());
 
@@ -120,7 +120,7 @@ final class CatalogueMessage
         return $translations;
     }
 
-    public function getSourceLocations()
+    public function getSourceLocations(): array
     {
         if (null === $this->metadata) {
             return [];
@@ -129,7 +129,7 @@ final class CatalogueMessage
         return $this->metadata->getSourceLocations();
     }
 
-    public function isNew()
+    public function isNew(): bool
     {
         if (null === $this->metadata) {
             return false;
@@ -138,7 +138,7 @@ final class CatalogueMessage
         return 'new' === $this->metadata->getState();
     }
 
-    public function isObsolete()
+    public function isObsolete(): bool
     {
         if (null === $this->metadata) {
             return false;
@@ -147,7 +147,7 @@ final class CatalogueMessage
         return 'obsolete' === $this->metadata->getState();
     }
 
-    public function isApproved()
+    public function isApproved(): bool
     {
         if (null === $this->metadata) {
             return false;

--- a/Model/CatalogueMessage.php
+++ b/Model/CatalogueMessage.php
@@ -67,9 +67,9 @@ final class CatalogueMessage
     }
 
     /**
-     * @param Metadata|null $metadata
+     * @param Metadata $metadata
      */
-    public function setMetadata(?Metadata $metadata)
+    public function setMetadata(Metadata $metadata): void
     {
         $this->metadata = $metadata;
     }

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -108,89 +108,56 @@ final class Configuration
         $this->xliffVersion = $data['xliff_version'];
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return array
-     */
     public function getLocales(): array
     {
         return $this->locales;
     }
 
-    /**
-     * @return string
-     */
     public function getProjectRoot(): string
     {
         return $this->projectRoot;
     }
 
-    /**
-     * @return string
-     */
     public function getOutputDir(): string
     {
         return $this->outputDir;
     }
 
-    /**
-     * @return array
-     */
     public function getDirs(): array
     {
         return $this->dirs;
     }
 
-    /**
-     * @return array
-     */
     public function getExcludedDirs(): array
     {
         return $this->excludedDirs;
     }
 
-    /**
-     * @return array
-     */
     public function getExcludedNames(): array
     {
         return $this->excludedNames;
     }
 
-    /**
-     * @return array
-     */
     public function getExternalTranslationsDirs(): array
     {
         return $this->externalTranslationsDirs;
     }
 
-    /**
-     * @return string
-     */
     public function getOutputFormat(): string
     {
         return $this->outputFormat;
     }
 
-    /**
-     * @return array
-     */
     public function getBlacklistDomains(): array
     {
         return $this->blacklistDomains;
     }
 
-    /**
-     * @return array
-     */
     public function getWhitelistDomains(): array
     {
         return $this->whitelistDomains;
@@ -199,17 +166,12 @@ final class Configuration
     /**
      * Get all paths where translation paths are stored. Both external files and
      * files created by us.
-     *
-     * @return array
      */
     public function getPathsToTranslationFiles(): array
     {
         return \array_merge($this->externalTranslationsDirs, [$this->getOutputDir()]);
     }
 
-    /**
-     * @return string
-     */
     public function getXliffVersion(): string
     {
         return $this->xliffVersion;
@@ -218,9 +180,6 @@ final class Configuration
     /**
      * Reconfigures the directories so we can use one configuration for extracting
      * the messages only from one bundle.
-     *
-     * @param string $bundleDir
-     * @param string $outputDir
      */
     public function reconfigureBundleDirs(string $bundleDir, string $outputDir): void
     {

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -114,7 +114,7 @@ final class Configuration
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -122,7 +122,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getLocales()
+    public function getLocales(): array
     {
         return $this->locales;
     }
@@ -130,7 +130,7 @@ final class Configuration
     /**
      * @return string
      */
-    public function getProjectRoot()
+    public function getProjectRoot(): string
     {
         return $this->projectRoot;
     }
@@ -138,7 +138,7 @@ final class Configuration
     /**
      * @return string
      */
-    public function getOutputDir()
+    public function getOutputDir(): string
     {
         return $this->outputDir;
     }
@@ -146,7 +146,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getDirs()
+    public function getDirs(): array
     {
         return $this->dirs;
     }
@@ -154,7 +154,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getExcludedDirs()
+    public function getExcludedDirs(): array
     {
         return $this->excludedDirs;
     }
@@ -162,7 +162,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getExcludedNames()
+    public function getExcludedNames(): array
     {
         return $this->excludedNames;
     }
@@ -170,7 +170,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getExternalTranslationsDirs()
+    public function getExternalTranslationsDirs(): array
     {
         return $this->externalTranslationsDirs;
     }
@@ -178,7 +178,7 @@ final class Configuration
     /**
      * @return string
      */
-    public function getOutputFormat()
+    public function getOutputFormat(): string
     {
         return $this->outputFormat;
     }
@@ -186,7 +186,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getBlacklistDomains()
+    public function getBlacklistDomains(): array
     {
         return $this->blacklistDomains;
     }
@@ -194,7 +194,7 @@ final class Configuration
     /**
      * @return array
      */
-    public function getWhitelistDomains()
+    public function getWhitelistDomains(): array
     {
         return $this->whitelistDomains;
     }
@@ -205,7 +205,7 @@ final class Configuration
      *
      * @return array
      */
-    public function getPathsToTranslationFiles()
+    public function getPathsToTranslationFiles(): array
     {
         return \array_merge($this->externalTranslationsDirs, [$this->getOutputDir()]);
     }
@@ -213,7 +213,7 @@ final class Configuration
     /**
      * @return string
      */
-    public function getXliffVersion()
+    public function getXliffVersion(): string
     {
         return $this->xliffVersion;
     }
@@ -225,9 +225,9 @@ final class Configuration
      * @param string $bundleDir
      * @param string $outputDir
      */
-    public function reconfigureBundleDirs($bundleDir, $outputDir)
+    public function reconfigureBundleDirs(string $bundleDir, string $outputDir): void
     {
-        $this->dirs = \is_array($bundleDir) ? $bundleDir : [$bundleDir];
+        $this->dirs = [$bundleDir];
         $this->outputDir = $outputDir;
     }
 }

--- a/Model/ImportResult.php
+++ b/Model/ImportResult.php
@@ -44,7 +44,7 @@ final class ImportResult
     /**
      * @return MessageCatalogueInterface[]
      */
-    public function getMessageCatalogues()
+    public function getMessageCatalogues(): array
     {
         return $this->messageCatalogues;
     }
@@ -52,7 +52,7 @@ final class ImportResult
     /**
      * @return Error[]
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/Model/Metadata.php
+++ b/Model/Metadata.php
@@ -21,7 +21,7 @@ final class Metadata
     /**
      * @var array
      */
-    private $metadata;
+    private $metadata = [];
 
     /**
      * @var array
@@ -29,7 +29,7 @@ final class Metadata
     private $notes = [];
 
     /**
-     * @param array $metadata
+     * @param array|null $metadata
      */
     public function __construct($metadata)
     {
@@ -43,9 +43,6 @@ final class Metadata
         }
     }
 
-    /**
-     * @return string|null
-     */
     public function getState(): ?string
     {
         $notes = $this->getAllInCategory('state');
@@ -58,18 +55,12 @@ final class Metadata
         return null;
     }
 
-    /**
-     * @param string $state
-     */
     public function setState(string $state): void
     {
         $this->removeAllInCategory('state');
         $this->addCategory('state', $state);
     }
 
-    /**
-     * @return string|null
-     */
     public function getDesc(): ?string
     {
         $notes = $this->getAllInCategory('desc');
@@ -84,8 +75,6 @@ final class Metadata
 
     /**
      * Get the extracted translation if any.
-     *
-     * @return string|null
      */
     public function getTranslation(): ?string
     {
@@ -99,9 +88,6 @@ final class Metadata
         return null;
     }
 
-    /**
-     * @return bool
-     */
     public function isApproved(): bool
     {
         $notes = $this->getAllInCategory('approved');
@@ -114,18 +100,12 @@ final class Metadata
         return false;
     }
 
-    /**
-     * @param bool $bool
-     */
-    public function setApproved(bool $bool)
+    public function setApproved(bool $bool): void
     {
         $this->removeAllInCategory('approved');
         $this->addCategory('approved', $bool ? 'true' : 'false');
     }
 
-    /**
-     * @return array
-     */
     public function getSourceLocations(): array
     {
         $sources = [];
@@ -143,19 +123,12 @@ final class Metadata
 
     /**
      * Add metadata.
-     *
-     * @param string $name
-     * @param string $content
-     * @param int    $priority
      */
-    public function addCategory(string $name, string $content, int $priority = 1)
+    public function addCategory(string $name, string $content, int $priority = 1): void
     {
         $this->notes[] = ['category' => $name, 'content' => $content, 'priority' => $priority];
     }
 
-    /**
-     * @return array
-     */
     public function toArray(): array
     {
         $metadata = $this->metadata;
@@ -166,12 +139,8 @@ final class Metadata
 
     /**
      * Return all notes for one category. It will also order data according to priority.
-     *
-     * @param string $category
-     *
-     * @return array
      */
-    public function getAllInCategory($category): array
+    public function getAllInCategory(string $category): array
     {
         $data = [];
         foreach ($this->notes as $note) {
@@ -195,8 +164,6 @@ final class Metadata
 
     /**
      * Remove all metadata in category.
-     *
-     * @param string $category
      */
     public function removeAllInCategory(string $category): void
     {

--- a/Model/Metadata.php
+++ b/Model/Metadata.php
@@ -46,7 +46,7 @@ final class Metadata
     /**
      * @return string|null
      */
-    public function getState()
+    public function getState(): ?string
     {
         $notes = $this->getAllInCategory('state');
         foreach ($notes as $note) {
@@ -54,12 +54,14 @@ final class Metadata
                 return $note['content'];
             }
         }
+
+        return null;
     }
 
     /**
      * @param string $state
      */
-    public function setState($state)
+    public function setState(string $state): void
     {
         $this->removeAllInCategory('state');
         $this->addCategory('state', $state);
@@ -68,7 +70,7 @@ final class Metadata
     /**
      * @return string|null
      */
-    public function getDesc()
+    public function getDesc(): ?string
     {
         $notes = $this->getAllInCategory('desc');
         foreach ($notes as $note) {
@@ -85,7 +87,7 @@ final class Metadata
      *
      * @return string|null
      */
-    public function getTranslation()
+    public function getTranslation(): ?string
     {
         $notes = $this->getAllInCategory('translation');
         foreach ($notes as $note) {
@@ -100,7 +102,7 @@ final class Metadata
     /**
      * @return bool
      */
-    public function isApproved()
+    public function isApproved(): bool
     {
         $notes = $this->getAllInCategory('approved');
         foreach ($notes as $note) {
@@ -115,7 +117,7 @@ final class Metadata
     /**
      * @param bool $bool
      */
-    public function setApproved($bool)
+    public function setApproved(bool $bool)
     {
         $this->removeAllInCategory('approved');
         $this->addCategory('approved', $bool ? 'true' : 'false');
@@ -124,7 +126,7 @@ final class Metadata
     /**
      * @return array
      */
-    public function getSourceLocations()
+    public function getSourceLocations(): array
     {
         $sources = [];
         $notes = $this->getAllInCategory('file-source');
@@ -144,8 +146,9 @@ final class Metadata
      *
      * @param string $name
      * @param string $content
+     * @param int    $priority
      */
-    public function addCategory($name, $content, $priority = 1)
+    public function addCategory(string $name, string $content, int $priority = 1)
     {
         $this->notes[] = ['category' => $name, 'content' => $content, 'priority' => $priority];
     }
@@ -153,7 +156,7 @@ final class Metadata
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $metadata = $this->metadata;
         $metadata['notes'] = $this->notes;
@@ -168,7 +171,7 @@ final class Metadata
      *
      * @return array
      */
-    public function getAllInCategory($category)
+    public function getAllInCategory($category): array
     {
         $data = [];
         foreach ($this->notes as $note) {
@@ -183,7 +186,7 @@ final class Metadata
             }
         }
 
-        \usort($data, function (array $a, array $b) {
+        \usort($data, static function (array $a, array $b) {
             return (int) $a['priority'] - (int) $b['priority'];
         });
 
@@ -195,7 +198,7 @@ final class Metadata
      *
      * @param string $category
      */
-    public function removeAllInCategory($category)
+    public function removeAllInCategory(string $category): void
     {
         foreach ($this->notes as $i => $note) {
             if (isset($note['category']) && $note['category'] === $category) {

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -118,8 +118,6 @@ final class SfProfilerMessage
 
     /**
      * Convert to a Common\Model\MessageInterface.
-     *
-     * @return MessageInterface
      */
     public function convertToMessage(): MessageInterface
     {
@@ -147,19 +145,11 @@ final class SfProfilerMessage
         );
     }
 
-    /**
-     * @return int
-     */
     public function getCount(): int
     {
         return $this->count;
     }
 
-    /**
-     * @param int $count
-     *
-     * @return $this
-     */
     public function setCount(int $count): self
     {
         $this->count = $count;
@@ -167,19 +157,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDomain(): string
     {
         return $this->domain;
     }
 
-    /**
-     * @param string $domain
-     *
-     * @return $this
-     */
     public function setDomain(string $domain): self
     {
         $this->domain = $domain;
@@ -187,19 +169,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(): string
     {
         return $this->key;
     }
 
-    /**
-     * @param string $key
-     *
-     * @return $this
-     */
     public function setKey($key): self
     {
         $this->key = $key;
@@ -207,19 +181,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getLocale(): string
     {
         return $this->locale;
     }
 
-    /**
-     * @param string $locale
-     *
-     * @return $this
-     */
     public function setLocale(string $locale): self
     {
         $this->locale = $locale;
@@ -227,19 +193,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getState(): int
     {
         return $this->state;
     }
 
-    /**
-     * @param int $state
-     *
-     * @return $this
-     */
     public function setState(int $state): self
     {
         $this->state = $state;
@@ -247,19 +205,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getTranslation(): string
     {
         return $this->translation;
     }
 
-    /**
-     * @param string $translation
-     *
-     * @return $this
-     */
     public function setTranslation(string $translation): self
     {
         $this->translation = $translation;
@@ -267,19 +217,11 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getTransChoiceNumber(): int
     {
         return $this->transChoiceNumber;
     }
 
-    /**
-     * @param int $transChoiceNumber
-     *
-     * @return $this
-     */
     public function setTransChoiceNumber(int $transChoiceNumber): self
     {
         $this->transChoiceNumber = $transChoiceNumber;
@@ -287,9 +229,6 @@ final class SfProfilerMessage
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getParameters(): array
     {
         $pure = [];
@@ -303,19 +242,11 @@ final class SfProfilerMessage
         return $pure;
     }
 
-    /**
-     * @return bool
-     */
     public function hasParameters(): bool
     {
         return !empty($this->parameters);
     }
 
-    /**
-     * @param array $parameters
-     *
-     * @return $this
-     */
     public function setParameters(array $parameters): self
     {
         $this->parameters = $parameters;

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -87,7 +87,7 @@ final class SfProfilerMessage
      *
      * @return SfProfilerMessage
      */
-    public static function create(array $data)
+    public static function create(array $data): self
     {
         $message = new self();
         if (isset($data['id'])) {
@@ -123,7 +123,7 @@ final class SfProfilerMessage
      *
      * @return MessageInterface
      */
-    public function convertToMessage()
+    public function convertToMessage(): MessageInterface
     {
         $meta = [];
 
@@ -152,7 +152,7 @@ final class SfProfilerMessage
     /**
      * @return int
      */
-    public function getCount()
+    public function getCount(): int
     {
         return $this->count;
     }
@@ -162,7 +162,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setCount($count)
+    public function setCount(int $count): self
     {
         $this->count = $count;
 
@@ -172,7 +172,7 @@ final class SfProfilerMessage
     /**
      * @return string
      */
-    public function getDomain()
+    public function getDomain(): string
     {
         return $this->domain;
     }
@@ -182,7 +182,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setDomain($domain)
+    public function setDomain(string $domain)
     {
         $this->domain = $domain;
 
@@ -192,7 +192,7 @@ final class SfProfilerMessage
     /**
      * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -202,7 +202,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setKey($key)
+    public function setKey($key): string
     {
         $this->key = $key;
 
@@ -212,7 +212,7 @@ final class SfProfilerMessage
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
@@ -222,7 +222,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): self
     {
         $this->locale = $locale;
 
@@ -232,7 +232,7 @@ final class SfProfilerMessage
     /**
      * @return int
      */
-    public function getState()
+    public function getState(): int
     {
         return $this->state;
     }
@@ -242,7 +242,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setState($state)
+    public function setState(int $state): self
     {
         $this->state = $state;
 
@@ -252,7 +252,7 @@ final class SfProfilerMessage
     /**
      * @return string
      */
-    public function getTranslation()
+    public function getTranslation(): string
     {
         return $this->translation;
     }
@@ -262,7 +262,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setTranslation($translation)
+    public function setTranslation(string $translation): self
     {
         $this->translation = $translation;
 
@@ -272,7 +272,7 @@ final class SfProfilerMessage
     /**
      * @return int
      */
-    public function getTransChoiceNumber()
+    public function getTransChoiceNumber(): int
     {
         return $this->transChoiceNumber;
     }
@@ -282,7 +282,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setTransChoiceNumber($transChoiceNumber)
+    public function setTransChoiceNumber(int $transChoiceNumber): self
     {
         $this->transChoiceNumber = $transChoiceNumber;
 
@@ -292,7 +292,7 @@ final class SfProfilerMessage
     /**
      * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         $pure = [];
         foreach ($this->parameters as $p) {
@@ -308,7 +308,7 @@ final class SfProfilerMessage
     /**
      * @return bool
      */
-    public function hasParameters()
+    public function hasParameters(): bool
     {
         return !empty($this->parameters);
     }
@@ -318,7 +318,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setParameters($parameters)
+    public function setParameters(array $parameters): self
     {
         $this->parameters = $parameters;
 

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -202,7 +202,7 @@ final class SfProfilerMessage
      *
      * @return $this
      */
-    public function setKey($key): string
+    public function setKey($key): self
     {
         $this->key = $key;
 

--- a/Service/CacheClearer.php
+++ b/Service/CacheClearer.php
@@ -38,7 +38,7 @@ final class CacheClearer
      */
     private $filesystem;
 
-    public function __construct($kernelCacheDir, TranslatorInterface $translator, Filesystem $filesystem)
+    public function __construct(string $kernelCacheDir, TranslatorInterface $translator, Filesystem $filesystem)
     {
         $this->kernelCacheDir = $kernelCacheDir;
         $this->translator = $translator;
@@ -50,7 +50,7 @@ final class CacheClearer
      *
      * @param string|null $locale optional filter to clear only one locale
      */
-    public function clearAndWarmUp($locale = null)
+    public function clearAndWarmUp(?string $locale = null): void
     {
         $translationDir = \sprintf('%s/translations', $this->kernelCacheDir);
 

--- a/Service/ConfigurationManager.php
+++ b/Service/ConfigurationManager.php
@@ -25,9 +25,6 @@ final class ConfigurationManager
      */
     private $configuration = [];
 
-    /**
-     * @param string $name
-     */
     public function addConfiguration(string $name, Configuration $configuration): void
     {
         $this->configuration[$name] = $configuration;
@@ -35,8 +32,6 @@ final class ConfigurationManager
 
     /**
      * @param string|string[]|null $name
-     *
-     * @return Configuration|null
      */
     public function getConfiguration($name = null): ?Configuration
     {
@@ -58,9 +53,6 @@ final class ConfigurationManager
         return null;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstName(): ?string
     {
         foreach ($this->configuration as $name => $config) {
@@ -70,9 +62,6 @@ final class ConfigurationManager
         return null;
     }
 
-    /**
-     * @return array
-     */
     public function getNames(): array
     {
         return \array_keys($this->configuration);

--- a/Service/ConfigurationManager.php
+++ b/Service/ConfigurationManager.php
@@ -29,17 +29,17 @@ final class ConfigurationManager
      * @param string        $name
      * @param Configuration $configuration
      */
-    public function addConfiguration($name, Configuration $configuration)
+    public function addConfiguration(string $name, Configuration $configuration): void
     {
         $this->configuration[$name] = $configuration;
     }
 
     /**
-     * @param string $name
+     * @param string|string[]|null $name
      *
      * @return Configuration|null
      */
-    public function getConfiguration($name = null)
+    public function getConfiguration($name = null): ?Configuration
     {
         if (empty($name)) {
             return $this->getConfiguration('default');
@@ -55,22 +55,26 @@ final class ConfigurationManager
                 return $this->configuration[$name];
             }
         }
+
+        return null;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         foreach ($this->configuration as $name => $config) {
             return $name;
         }
+
+        return null;
     }
 
     /**
      * @return array
      */
-    public function getNames()
+    public function getNames(): array
     {
         return \array_keys($this->configuration);
     }

--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -50,9 +50,6 @@ final class Importer
      */
     private $defaultLocale;
 
-    /**
-     * @param string $defaultLocale
-     */
     public function __construct(Extractor $extractor, Environment $twig, string $defaultLocale)
     {
         $this->extractor = $extractor;
@@ -68,8 +65,6 @@ final class Importer
      *     @var array $whitelist_domains Whitelist the domains we should include. Cannot be used with blacklist.
      *     @var string $project_root The project root will be removed from the source location.
      * }
-     *
-     * @return ImportResult
      */
     public function extractToCatalogues(Finder $finder, array $catalogues, array $config = []): ImportResult
     {
@@ -152,31 +147,16 @@ final class Importer
         }
     }
 
-    /**
-     * @param $key
-     * @param $domain
-     *
-     * @return Metadata
-     */
     private function getMetadata(MessageCatalogue $catalogue, string $key, string $domain): Metadata
     {
         return new Metadata($catalogue->getMetadata($key, $domain));
     }
 
-    /**
-     * @param $key
-     * @param $domain
-     */
     private function setMetadata(MessageCatalogue $catalogue, string $key, string $domain, Metadata $metadata): void
     {
         $catalogue->setMetadata($key, $metadata->toArray(), $domain);
     }
 
-    /**
-     * @param string $domain
-     *
-     * @return bool
-     */
     private function isValidDomain(string $domain): bool
     {
         if (!empty($this->config['blacklist_domains']) && \in_array($domain, $this->config['blacklist_domains'], true)) {
@@ -191,8 +171,6 @@ final class Importer
 
     /**
      * Make sure the configuration is valid.
-     *
-     * @param array $config
      */
     private function processConfig(array $config): void
     {

--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -55,7 +55,7 @@ final class Importer
      * @param Environment $twig
      * @param string      $defaultLocale
      */
-    public function __construct(Extractor $extractor, Environment $twig, $defaultLocale)
+    public function __construct(Extractor $extractor, Environment $twig, string $defaultLocale)
     {
         $this->extractor = $extractor;
         $this->twig = $twig;
@@ -74,7 +74,7 @@ final class Importer
      *
      * @return ImportResult
      */
-    public function extractToCatalogues(Finder $finder, array $catalogues, array $config = [])
+    public function extractToCatalogues(Finder $finder, array $catalogues, array $config = []): ImportResult
     {
         $this->processConfig($config);
         $this->disableTwigVisitors();
@@ -132,12 +132,12 @@ final class Importer
      * @param MessageCatalogue $catalogue
      * @param SourceCollection $collection
      */
-    private function convertSourceLocationsToMessages(MessageCatalogue $catalogue, SourceCollection $collection)
+    private function convertSourceLocationsToMessages(MessageCatalogue $catalogue, SourceCollection $collection): void
     {
         /** @var SourceLocation $sourceLocation */
         foreach ($collection as $sourceLocation) {
             $context = $sourceLocation->getContext();
-            $domain = isset($context['domain']) ? $context['domain'] : 'messages';
+            $domain = $context['domain'] ?? 'messages';
             // Check with white/black list
             if (!$this->isValidDomain($domain)) {
                 continue;
@@ -166,7 +166,7 @@ final class Importer
      *
      * @return Metadata
      */
-    private function getMetadata(MessageCatalogue $catalogue, $key, $domain)
+    private function getMetadata(MessageCatalogue $catalogue, $key, $domain): Metadata
     {
         return new Metadata($catalogue->getMetadata($key, $domain));
     }
@@ -177,7 +177,7 @@ final class Importer
      * @param $domain
      * @param Metadata $metadata
      */
-    private function setMetadata(MessageCatalogue $catalogue, $key, $domain, Metadata $metadata)
+    private function setMetadata(MessageCatalogue $catalogue, $key, $domain, Metadata $metadata): void
     {
         $catalogue->setMetadata($key, $metadata->toArray(), $domain);
     }
@@ -187,12 +187,12 @@ final class Importer
      *
      * @return bool
      */
-    private function isValidDomain($domain)
+    private function isValidDomain(string $domain): bool
     {
-        if (!empty($this->config['blacklist_domains']) && \in_array($domain, $this->config['blacklist_domains'])) {
+        if (!empty($this->config['blacklist_domains']) && \in_array($domain, $this->config['blacklist_domains'], true)) {
             return false;
         }
-        if (!empty($this->config['whitelist_domains']) && !\in_array($domain, $this->config['whitelist_domains'])) {
+        if (!empty($this->config['whitelist_domains']) && !\in_array($domain, $this->config['whitelist_domains'], true)) {
             return false;
         }
 
@@ -204,7 +204,7 @@ final class Importer
      *
      * @param array $config
      */
-    private function processConfig($config)
+    private function processConfig(array $config): void
     {
         $default = [
             'project_root' => '',
@@ -229,7 +229,7 @@ final class Importer
         $this->config = $config;
     }
 
-    private function disableTwigVisitors()
+    private function disableTwigVisitors(): void
     {
         foreach ($this->twig->getNodeVisitors() as $visitor) {
             if ($visitor instanceof DefaultApplyingNodeVisitor) {

--- a/Service/StorageManager.php
+++ b/Service/StorageManager.php
@@ -23,9 +23,6 @@ final class StorageManager
      */
     private $storages = [];
 
-    /**
-     * @param string $name
-     */
     public function addStorage(string $name, StorageService $storage): void
     {
         $this->storages[$name] = $storage;
@@ -33,8 +30,6 @@ final class StorageManager
 
     /**
      * @param string|string[]|null $name
-     *
-     * @return StorageService|null
      */
     public function getStorage($name = null): ?StorageService
     {
@@ -56,9 +51,6 @@ final class StorageManager
         return null;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFirstName(): ?string
     {
         foreach ($this->storages as $name => $config) {
@@ -68,9 +60,6 @@ final class StorageManager
         return null;
     }
 
-    /**
-     * @return array
-     */
     public function getNames(): array
     {
         return \array_keys($this->storages);

--- a/Service/StorageManager.php
+++ b/Service/StorageManager.php
@@ -27,17 +27,17 @@ final class StorageManager
      * @param string         $name
      * @param StorageService $storage
      */
-    public function addStorage($name, StorageService $storage)
+    public function addStorage(string $name, StorageService $storage): void
     {
         $this->storages[$name] = $storage;
     }
 
     /**
-     * @param string $name
+     * @param string|string[]|null $name
      *
      * @return StorageService|null
      */
-    public function getStorage($name = null)
+    public function getStorage($name = null): ?StorageService
     {
         if (empty($name)) {
             return $this->getStorage('default');
@@ -53,22 +53,26 @@ final class StorageManager
                 return $this->storages[$name];
             }
         }
+
+        return null;
     }
 
     /**
      * @return string|null
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         foreach ($this->storages as $name => $config) {
             return $name;
         }
+
+        return null;
     }
 
     /**
      * @return array
      */
-    public function getNames()
+    public function getNames(): array
     {
         return \array_keys($this->storages);
     }

--- a/Service/StorageService.php
+++ b/Service/StorageService.php
@@ -76,7 +76,7 @@ final class StorageService implements Storage
      * Download all remote storages into all local storages.
      * This will overwrite your local copy.
      */
-    public function download()
+    public function download(): void
     {
         $catalogues = $this->doDownload();
 
@@ -85,8 +85,10 @@ final class StorageService implements Storage
 
     /**
      * Synchronize translations with remote.
+     *
+     * @param string $direction
      */
-    public function sync($direction = self::DIRECTION_DOWN)
+    public function sync(string $direction = self::DIRECTION_DOWN): void
     {
         switch ($direction) {
             case self::DIRECTION_DOWN:
@@ -108,7 +110,7 @@ final class StorageService implements Storage
      * Download and merge all translations from remote storages down to your local storages.
      * Only the local storages will be changed.
      */
-    public function mergeDown()
+    public function mergeDown(): void
     {
         $catalogues = $this->doDownload();
 
@@ -128,7 +130,7 @@ final class StorageService implements Storage
      *
      * This will overwrite your remote copy.
      */
-    public function mergeUp()
+    public function mergeUp(): void
     {
         $catalogues = $this->catalogueFetcher->getCatalogues($this->config);
         foreach ($catalogues as $catalogue) {
@@ -150,7 +152,7 @@ final class StorageService implements Storage
      *
      * @return Message|null
      */
-    public function syncAndFetchMessage($locale, $domain, $key)
+    public function syncAndFetchMessage(string $locale, string $domain, string $key): ?Message
     {
         if (null === $message = $this->getFromStorages($this->remoteStorages, $locale, $domain, $key)) {
             // If message is not in remote storages, try local
@@ -158,7 +160,7 @@ final class StorageService implements Storage
         }
 
         if (!$message) {
-            return;
+            return null;
         }
 
         $this->updateStorages($this->localStorages, $message);
@@ -175,12 +177,12 @@ final class StorageService implements Storage
     {
         foreach ([$this->localStorages, $this->remoteStorages] as $storages) {
             $value = $this->getFromStorages($storages, $locale, $domain, $key);
-            if (!empty($value)) {
+            if (null !== $value) {
                 return $value;
             }
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -191,16 +193,16 @@ final class StorageService implements Storage
      *
      * @return Message|null
      */
-    private function getFromStorages(array $storages, $locale, $domain, $key)
+    private function getFromStorages(array $storages, string $locale, string $domain, string $key): ?Message
     {
         foreach ($storages as $storage) {
             $value = $storage->get($locale, $domain, $key);
-            if (!empty($value)) {
+            if (null !== $value) {
                 return $value;
             }
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -209,7 +211,7 @@ final class StorageService implements Storage
      *
      * {@inheritdoc}
      */
-    public function create(MessageInterface $message)
+    public function create(MessageInterface $message): void
     {
         // Validate if message actually has data
         if (empty((array) $message)) {
@@ -230,7 +232,7 @@ final class StorageService implements Storage
      *
      * {@inheritdoc}
      */
-    public function update(MessageInterface $message)
+    public function update(MessageInterface $message): void
     {
         foreach ([$this->localStorages, $this->remoteStorages] as $storages) {
             $this->updateStorages($storages, $message);
@@ -241,7 +243,7 @@ final class StorageService implements Storage
      * @param Storage[]        $storages
      * @param MessageInterface $message
      */
-    private function updateStorages(array $storages, MessageInterface $message)
+    private function updateStorages(array $storages, MessageInterface $message): void
     {
         // Validate if message actually has data
         if (empty((array) $message)) {
@@ -258,7 +260,7 @@ final class StorageService implements Storage
      *
      * {@inheritdoc}
      */
-    public function delete($locale, $domain, $key)
+    public function delete($locale, $domain, $key): void
     {
         foreach ([$this->localStorages, $this->remoteStorages] as $storages) {
             /** @var Storage $storage */
@@ -273,7 +275,7 @@ final class StorageService implements Storage
      *
      * @return StorageService
      */
-    public function addLocalStorage(Storage $localStorage)
+    public function addLocalStorage(Storage $localStorage): self
     {
         $this->localStorages[] = $localStorage;
 
@@ -285,7 +287,7 @@ final class StorageService implements Storage
      *
      * @return StorageService
      */
-    public function addRemoteStorage(Storage $remoteStorage)
+    public function addRemoteStorage(Storage $remoteStorage): self
     {
         $this->remoteStorages[] = $remoteStorage;
 
@@ -297,7 +299,7 @@ final class StorageService implements Storage
      *
      * @return MessageCatalogue[]
      */
-    private function doDownload()
+    private function doDownload(): array
     {
         $catalogues = [];
         foreach ($this->config->getLocales() as $locale) {

--- a/Service/StorageService.php
+++ b/Service/StorageService.php
@@ -80,8 +80,6 @@ final class StorageService implements Storage
 
     /**
      * Synchronize translations with remote.
-     *
-     * @param string $direction
      */
     public function sync(string $direction = self::DIRECTION_DOWN): void
     {
@@ -140,12 +138,6 @@ final class StorageService implements Storage
     /**
      * Get the very latest version we know of a message. First look at the remote storage
      * fall back on the local ones.
-     *
-     * @param string $locale
-     * @param string $domain
-     * @param string $key
-     *
-     * @return Message|null
      */
     public function syncAndFetchMessage(string $locale, string $domain, string $key): ?Message
     {
@@ -168,7 +160,7 @@ final class StorageService implements Storage
      * local storage and then move on to the remote storages.
      * {@inheritdoc}
      */
-    public function get($locale, $domain, $key)
+    public function get($locale, $domain, $key): ?Message
     {
         foreach ([$this->localStorages, $this->remoteStorages] as $storages) {
             $value = $this->getFromStorages($storages, $locale, $domain, $key);
@@ -182,11 +174,6 @@ final class StorageService implements Storage
 
     /**
      * @param Storage[] $storages
-     * @param string    $locale
-     * @param string    $domain
-     * @param string    $key
-     *
-     * @return Message|null
      */
     private function getFromStorages(array $storages, string $locale, string $domain, string $key): ?Message
     {
@@ -264,9 +251,6 @@ final class StorageService implements Storage
         }
     }
 
-    /**
-     * @return StorageService
-     */
     public function addLocalStorage(Storage $localStorage): self
     {
         $this->localStorages[] = $localStorage;
@@ -274,9 +258,6 @@ final class StorageService implements Storage
         return $this;
     }
 
-    /**
-     * @return StorageService
-     */
     public function addRemoteStorage(Storage $remoteStorage): self
     {
         $this->remoteStorages[] = $remoteStorage;

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -27,12 +27,12 @@ abstract class BaseTestCase extends BaseBundleTestCase
      */
     protected $kernel;
 
-    protected function getBundleClass()
+    protected function getBundleClass(): string
     {
         return FrameworkBundle::class;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = $this->createKernel();
         $kernel->addConfigFile(__DIR__.'/app/config/default.yml');

--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -22,7 +22,7 @@ use Translation\Extractor\FileExtractor\TwigFileExtractor;
 
 class BundleInitializationTest extends BaseTestCase
 {
-    public function testRegisterBundle()
+    public function testRegisterBundle(): void
     {
         $this->bootKernel();
         $container = $this->getContainer();

--- a/Tests/Functional/Catalogue/CatalogueFetcherTest.php
+++ b/Tests/Functional/Catalogue/CatalogueFetcherTest.php
@@ -67,9 +67,6 @@ XML
         $this->assertEquals('sv', $catalogues[0]->getLocale());
     }
 
-    /**
-     * @return array
-     */
     public static function getDefaultData(): array
     {
         return [

--- a/Tests/Functional/Catalogue/CatalogueFetcherTest.php
+++ b/Tests/Functional/Catalogue/CatalogueFetcherTest.php
@@ -21,7 +21,7 @@ class CatalogueFetcherTest extends BaseTestCase
      */
     private $catalogueFetcher;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -50,7 +50,7 @@ XML
         );
     }
 
-    public function testFetchCatalogue()
+    public function testFetchCatalogue(): void
     {
         $this->bootKernel();
 
@@ -70,7 +70,7 @@ XML
     /**
      * @return array
      */
-    public static function getDefaultData()
+    public static function getDefaultData(): array
     {
         return [
             'name' => 'getName',
@@ -88,7 +88,7 @@ XML
         ];
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -18,7 +18,7 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
 
 class ExtractCommandTest extends BaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
@@ -61,7 +61,7 @@ XML
         );
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->bootKernel();
         $application = new Application($this->kernel);

--- a/Tests/Functional/Command/StatusCommandTest.php
+++ b/Tests/Functional/Command/StatusCommandTest.php
@@ -17,13 +17,13 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
 
 class StatusCommandTest extends BaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->bootKernel();
         $application = new Application($this->kernel);

--- a/Tests/Functional/Command/SyncCommandTest.php
+++ b/Tests/Functional/Command/SyncCommandTest.php
@@ -17,7 +17,7 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
 
 class SyncCommandTest extends BaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
@@ -60,7 +60,7 @@ XML
         );
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->bootKernel();
         $application = new Application($this->kernel);

--- a/Tests/Functional/Controller/EditInPlaceControllerTest.php
+++ b/Tests/Functional/Controller/EditInPlaceControllerTest.php
@@ -19,7 +19,7 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
  */
 class EditInPlaceControllerTest extends BaseTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -46,13 +46,13 @@ XML
         );
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
     }
 
-    public function testEditAction()
+    public function testEditAction(): void
     {
         $request = Request::create('/admin/_trans_edit_in_place/app/sv', 'POST', [], [], [], [], \json_encode([
             'messages|key0' => 'trans0',
@@ -62,7 +62,7 @@ XML
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testEditActionError()
+    public function testEditActionError(): void
     {
         $request = Request::create('/admin/_trans_edit_in_place/app/sv', 'POST', [], [], [], [], \json_encode([
             'messages|key0' => 'trans0',

--- a/Tests/Functional/Controller/EditInPlaceTest.php
+++ b/Tests/Functional/Controller/EditInPlaceTest.php
@@ -19,7 +19,7 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
  */
 class EditInPlaceTest extends BaseTestCase
 {
-    public function testActivatedTest()
+    public function testActivatedTest(): void
     {
         $this->bootKernel();
         $request = Request::create('/foobar');
@@ -50,7 +50,7 @@ class EditInPlaceTest extends BaseTestCase
         self::assertEquals('🚫 Can\'t be translated here. 🚫', $attributeDiv->getAttribute('data-value'));
     }
 
-    public function testIfUntranslatableLabelGetsDisabled()
+    public function testIfUntranslatableLabelGetsDisabled(): void
     {
         $this->kernel->addConfigFile(__DIR__.'/../app/config/disabled_label.yml');
         $request = Request::create('/foobar');
@@ -82,7 +82,7 @@ class EditInPlaceTest extends BaseTestCase
         self::assertEquals('translated.attribute', $attributeDiv->getAttribute('data-value'));
     }
 
-    public function testDeactivatedTest()
+    public function testDeactivatedTest(): void
     {
         $this->bootKernel();
         $request = Request::create('/foobar');

--- a/Tests/Functional/Controller/WebUIControllerTest.php
+++ b/Tests/Functional/Controller/WebUIControllerTest.php
@@ -16,7 +16,7 @@ use Translation\Bundle\Tests\Functional\BaseTestCase;
 
 class WebUIControllerTest extends BaseTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -43,13 +43,13 @@ XML
     );
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yml');
     }
 
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         $request = Request::create('/_trans', 'GET');
         $response = $this->kernel->handle($request);
@@ -60,14 +60,14 @@ XML
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testShowAction()
+    public function testShowAction(): void
     {
         $request = Request::create('/_trans/app/en/messages', 'GET');
         $response = $this->kernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testCreateAction()
+    public function testCreateAction(): void
     {
         $request = Request::create('/_trans/app/sv/messages/new', 'POST', [], [], [], [], \json_encode([
             'key' => 'foo',
@@ -83,7 +83,7 @@ XML
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testEditAction()
+    public function testEditAction(): void
     {
         $request = Request::create('/_trans/app/sv/messages', 'POST', [], [], [], [], \json_encode([
             'key' => 'foo',
@@ -99,7 +99,7 @@ XML
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testDeleteAction()
+    public function testDeleteAction(): void
     {
         // Removing something that does not exists is okey.
         $request = Request::create('/_trans/app/sv/messages', 'DELETE', [], [], [], [], \json_encode([

--- a/Tests/Functional/app/Controller/TestController.php
+++ b/Tests/Functional/app/Controller/TestController.php
@@ -12,13 +12,14 @@
 namespace Translation\Bundle\Tests\Functional\app\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Damien Alexandre <dalexandre@jolicode.com>
  */
 class TestController extends Controller
 {
-    public function translatedAction()
+    public function translatedAction(): Response
     {
         return $this->render('@App/translated.html.twig');
     }

--- a/Tests/Functional/app/Service/DummyLogger.php
+++ b/Tests/Functional/app/Service/DummyLogger.php
@@ -15,39 +15,39 @@ use Psr\Log\LoggerInterface;
 
 class DummyLogger implements LoggerInterface
 {
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
     }
 
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
     }
 
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
     }
 
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
     }
 
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
     }
 
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
     }
 
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
     }
 
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
     }
 }

--- a/Tests/Unit/Catalogue/CatalogueManagerTest.php
+++ b/Tests/Unit/Catalogue/CatalogueManagerTest.php
@@ -21,7 +21,7 @@ use Translation\Bundle\Model\CatalogueMessage;
  */
 class CatalogueManagerTest extends TestCase
 {
-    public function testGetMessages()
+    public function testGetMessages(): void
     {
         $manager = new CatalogueManager();
         $catA = new MessageCatalogue('en', ['messages' => ['a' => 'aTrans', 'b' => 'bTrans']]);
@@ -32,7 +32,7 @@ class CatalogueManagerTest extends TestCase
         $this->assertCount(2, $messages);
     }
 
-    public function testFindMessagesNoMetadata()
+    public function testFindMessagesNoMetadata(): void
     {
         $manager = new CatalogueManager();
         $catA = new MessageCatalogue('en', ['messages' => ['a' => 'aTrans', 'b' => 'bTrans']]);
@@ -43,7 +43,7 @@ class CatalogueManagerTest extends TestCase
         $this->assertCount(2, $messages);
     }
 
-    public function testFindMessages()
+    public function testFindMessages(): void
     {
         $manager = new CatalogueManager();
         $catA = new MessageCatalogue('en', ['messages' => ['a' => 'aTrans', 'b' => 'bTrans', 'c' => 'cTrans', 'd' => 'dTrans']]);

--- a/Tests/Unit/Catalogue/Operation/ReplaceOperationTest.php
+++ b/Tests/Unit/Catalogue/Operation/ReplaceOperationTest.php
@@ -18,7 +18,7 @@ use Translation\Bundle\Catalogue\Operation\ReplaceOperation;
 
 class ReplaceOperationTest extends MergeOperationTest
 {
-    public function testGetMessagesFromSingleDomain()
+    public function testGetMessagesFromSingleDomain(): void
     {
         $operation = $this->createOperation(
             new MessageCatalogue('en', ['messages' => ['a' => 'new_a', 'c' => 'new_c']]),
@@ -41,7 +41,7 @@ class ReplaceOperationTest extends MergeOperationTest
         );
     }
 
-    public function testGetResultFromSingleDomain()
+    public function testGetResultFromSingleDomain(): void
     {
         $this->assertEquals(
             new MessageCatalogue('en', [
@@ -54,7 +54,7 @@ class ReplaceOperationTest extends MergeOperationTest
         );
     }
 
-    public function testGetResultWithNullValues()
+    public function testGetResultWithNullValues(): void
     {
         $this->assertEquals(
             new MessageCatalogue('en', [
@@ -67,7 +67,7 @@ class ReplaceOperationTest extends MergeOperationTest
         );
     }
 
-    public function testGetResultWithMetadata()
+    public function testGetResultWithMetadata(): void
     {
         $leftCatalogue = new MessageCatalogue('en', ['messages' => ['a' => 'new_a', 'b' => 'new_b']]);
         $leftCatalogue->setMetadata('a', 'foo', 'messages');
@@ -87,7 +87,7 @@ class ReplaceOperationTest extends MergeOperationTest
         );
     }
 
-    public function testGetResultWithArrayMetadata()
+    public function testGetResultWithArrayMetadata(): void
     {
         $leftCatalogue = new MessageCatalogue('en', ['messages' => ['a' => 'new_a', 'b' => 'new_b']]);
         $notes = [
@@ -131,7 +131,7 @@ class ReplaceOperationTest extends MergeOperationTest
         }
     }
 
-    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target): ReplaceOperation
     {
         return new ReplaceOperation($source, $target);
     }

--- a/Tests/Unit/DependencyInjection/CompilerPass/EditInPlacePassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/EditInPlacePassTest.php
@@ -19,12 +19,12 @@ use Translation\Bundle\DependencyInjection\CompilerPass\EditInPlacePass;
 
 class EditInPlacePassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new EditInPlacePass());
     }
 
-    public function testReplacement()
+    public function testReplacement(): void
     {
         $def = new Definition();
         $this->setDefinition('php_translator.edit_in_place.xtrans_html_translator', $def);

--- a/Tests/Unit/DependencyInjection/CompilerPass/ExternalTranslatorPassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/ExternalTranslatorPassTest.php
@@ -19,7 +19,7 @@ use Translation\Bundle\DependencyInjection\CompilerPass\ExternalTranslatorPass;
 
 class ExternalTranslatorPassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ExternalTranslatorPass());
     }
@@ -27,7 +27,7 @@ class ExternalTranslatorPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist()
+    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist(): void
     {
         $collectingService = new Definition();
         $this->setDefinition('php_translation.translator_service.external_translator', $collectingService);

--- a/Tests/Unit/DependencyInjection/CompilerPass/ExtractorPassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/ExtractorPassTest.php
@@ -19,7 +19,7 @@ use Translation\Bundle\DependencyInjection\CompilerPass\ExtractorPass;
 
 class ExtractorPassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ExtractorPass());
     }
@@ -27,7 +27,7 @@ class ExtractorPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist()
+    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist(): void
     {
         $collectingService = new Definition();
         $this->setDefinition('php_translation.extractor', $collectingService);

--- a/Tests/Unit/DependencyInjection/CompilerPass/LoaderOrReaderPassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/LoaderOrReaderPassTest.php
@@ -18,12 +18,12 @@ use Translation\Bundle\DependencyInjection\CompilerPass\LoaderOrReaderPass;
 
 class LoaderOrReaderPassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new LoaderOrReaderPass());
     }
 
-    public function testLoaderOrReader()
+    public function testLoaderOrReader(): void
     {
         $def = new Definition();
         $this->setDefinition('translation.reader', $def);

--- a/Tests/Unit/DependencyInjection/CompilerPass/StoragePassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/StoragePassTest.php
@@ -19,7 +19,7 @@ use Translation\Bundle\DependencyInjection\CompilerPass\StoragePass;
 
 class StoragePassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new StoragePass());
     }
@@ -27,7 +27,7 @@ class StoragePassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist()
+    public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist(): void
     {
         $collectingService = new Definition();
         $this->setDefinition('php_translation.storage.foobar', $collectingService);

--- a/Tests/Unit/DependencyInjection/TranslationExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/TranslationExtensionTest.php
@@ -20,7 +20,7 @@ use Translation\Bundle\Translator\FallbackTranslator;
 
 class TranslationExtensionTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         $this->setParameter('kernel.default_locale', 'ar');
         $this->setParameter('kernel.root_dir', __DIR__);
@@ -31,7 +31,7 @@ class TranslationExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
-    public function testLocales()
+    public function testLocales(): void
     {
         $locales = ['fr', 'sv'];
         $this->load(['locales' => $locales]);
@@ -40,49 +40,49 @@ class TranslationExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('php_translation.default_locale', 'ar');
     }
 
-    public function testDefaultLocales()
+    public function testDefaultLocales(): void
     {
         $this->load(['default_locale' => 'sv']);
 
         $this->assertContainerBuilderHasParameter('php_translation.default_locale', 'sv');
     }
 
-    public function testWebUiEnabled()
+    public function testWebUiEnabled(): void
     {
         $this->load(['webui' => ['enabled' => true]]);
 
         $this->assertContainerBuilderHasParameter('php_translation.webui.enabled', true);
     }
 
-    public function testWebUiDisabled()
+    public function testWebUiDisabled(): void
     {
         $this->load(['webui' => ['enabled' => false]]);
 
         $this->assertContainerBuilderHasParameter('php_translation.webui.enabled', false);
     }
 
-    public function testSymfonyProfilerEnabled()
+    public function testSymfonyProfilerEnabled(): void
     {
         $this->load(['symfony_profiler' => ['enabled' => true]]);
 
         $this->assertContainerBuilderHasService('php_translation.data_collector', TranslationDataCollector::class);
     }
 
-    public function testEditInPlaceEnabled()
+    public function testEditInPlaceEnabled(): void
     {
         $this->load(['edit_in_place' => ['enabled' => true]]);
 
         $this->assertContainerBuilderHasService('php_translation.edit_in_place.response_listener', EditInPlaceResponseListener::class);
     }
 
-    public function testAutoAddEnabled()
+    public function testAutoAddEnabled(): void
     {
         $this->load(['auto_add_missing_translations' => ['enabled' => true]]);
 
         $this->assertContainerBuilderHasService('php_translator.auto_adder', AutoAddMissingTranslations::class);
     }
 
-    public function testFallbackTranslationEnabled()
+    public function testFallbackTranslationEnabled(): void
     {
         $this->load(['fallback_translation' => ['enabled' => true]]);
 

--- a/Tests/Unit/Model/ConfigurationTest.php
+++ b/Tests/Unit/Model/ConfigurationTest.php
@@ -41,9 +41,6 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'biz'], $conf->getPathsToTranslationFiles());
     }
 
-    /**
-     * @return array
-     */
     public static function getDefaultData(): array
     {
         return [

--- a/Tests/Unit/Model/ConfigurationTest.php
+++ b/Tests/Unit/Model/ConfigurationTest.php
@@ -16,7 +16,7 @@ use Translation\Bundle\Model\Configuration;
 
 class ConfigurationTest extends TestCase
 {
-    public function testAccessors()
+    public function testAccessors(): void
     {
         $key2Function = self::getDefaultData();
         $conf = new Configuration($key2Function);
@@ -26,11 +26,11 @@ class ConfigurationTest extends TestCase
             if (\is_array($func)) {
                 $func = \reset($func);
             }
-            $this->assertEquals($value, \call_user_func([$conf, $func]));
+            $this->assertEquals($value, $conf->$func());
         }
     }
 
-    public function testGetPathsToTranslationFiles()
+    public function testGetPathsToTranslationFiles(): void
     {
         $data = self::getDefaultData();
         $data['external_translations_dirs'] = ['foo', 'bar'];
@@ -44,7 +44,7 @@ class ConfigurationTest extends TestCase
     /**
      * @return array
      */
-    public static function getDefaultData()
+    public static function getDefaultData(): array
     {
         return [
             'name' => 'getName',
@@ -58,7 +58,7 @@ class ConfigurationTest extends TestCase
             'output_format' => 'getOutputFormat',
             'blacklist_domains' => ['getBlacklistDomains'],
             'whitelist_domains' => ['getWhitelistDomains'],
-            'xliff_version' => ['getXliffVersion'],
+            'xliff_version' => 'getXliffVersion',
         ];
     }
 }

--- a/Tests/Unit/Service/ConfigurationManagerTest.php
+++ b/Tests/Unit/Service/ConfigurationManagerTest.php
@@ -18,7 +18,7 @@ use Translation\Bundle\Tests\Unit\Model\ConfigurationTest;
 
 class ConfigurationManagerTest extends TestCase
 {
-    public function testGetConfigurationFirst()
+    public function testGetConfigurationFirst(): void
     {
         $manager = new ConfigurationManager();
         $correctConfiguration = $this->createConfiguration(['name' => 'correct']);
@@ -30,7 +30,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals($correctConfiguration, $manager->getConfiguration('default'));
     }
 
-    public function testGetConfigurationDefault()
+    public function testGetConfigurationDefault(): void
     {
         $manager = new ConfigurationManager();
         $correctConfiguration = $this->createConfiguration(['name' => 'correct']);
@@ -44,7 +44,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals($correctConfiguration, $manager->getConfiguration(null));
     }
 
-    public function testGetConfigurationMissing()
+    public function testGetConfigurationMissing(): void
     {
         $manager = new ConfigurationManager();
         $correctConfiguration = $this->createConfiguration(['name' => 'correct']);
@@ -55,7 +55,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertNull($manager->getConfiguration('missing'));
     }
 
-    public function testFirstName()
+    public function testFirstName(): void
     {
         $manager = new ConfigurationManager();
         $manager->addConfiguration('foo', $this->createConfiguration());
@@ -64,14 +64,14 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals('foo', $manager->getFirstName());
     }
 
-    public function testFirstNameEmpty()
+    public function testFirstNameEmpty(): void
     {
         $manager = new ConfigurationManager();
 
         $this->assertNull($manager->getFirstName());
     }
 
-    public function testGetNames()
+    public function testGetNames(): void
     {
         $manager = new ConfigurationManager();
         $manager->addConfiguration('foo', $this->createConfiguration());
@@ -81,7 +81,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $names);
     }
 
-    public function testGetNamesEmpty()
+    public function testGetNamesEmpty(): void
     {
         $manager = new ConfigurationManager();
 
@@ -89,7 +89,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals([], $names);
     }
 
-    private function createConfiguration($data = [])
+    private function createConfiguration(array $data = []): Configuration
     {
         $default = ConfigurationTest::getDefaultData();
 

--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -24,7 +24,7 @@ use Translation\Bundle\Translator\EditInPlaceTranslator;
  */
 final class EditInPlaceTranslatorTest extends TestCase
 {
-    public function testEnabled()
+    public function testEnabled(): void
     {
         $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
 
@@ -41,7 +41,7 @@ final class EditInPlaceTranslatorTest extends TestCase
         );
     }
 
-    public function testDisabled()
+    public function testDisabled(): void
     {
         $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
 
@@ -57,7 +57,7 @@ final class EditInPlaceTranslatorTest extends TestCase
         );
     }
 
-    public function testHtmlTranslation()
+    public function testHtmlTranslation(): void
     {
         $symfonyTranslator = new \Symfony\Component\Translation\Translator('en', null, null, true);
         $symfonyTranslator->addLoader('array', new ArrayLoader());
@@ -93,12 +93,12 @@ class FakeActivator implements ActivatorInterface
 {
     private $enabled;
 
-    public function __construct($enabled = true)
+    public function __construct(bool $enabled = true)
     {
         $this->enabled = $enabled;
     }
 
-    public function checkRequest(Request $request = null)
+    public function checkRequest(Request $request = null): bool
     {
         return $this->enabled;
     }

--- a/Tests/Unit/Translator/FallbackTranslatorTest.php
+++ b/Tests/Unit/Translator/FallbackTranslatorTest.php
@@ -23,7 +23,7 @@ use Translation\Translator\TranslatorService;
  */
 final class FallbackTranslatorTest extends TestCase
 {
-    public function testTranslateWithSubstitutedParameters()
+    public function testTranslateWithSubstitutedParameters(): void
     {
         $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
 

--- a/Tests/Unit/Twig/BaseTwigTestCase.php
+++ b/Tests/Unit/Twig/BaseTwigTestCase.php
@@ -25,7 +25,7 @@ use Twig\Source;
  */
 abstract class BaseTwigTestCase extends TestCase
 {
-    final protected function parse($file, $debug = false)
+    final protected function parse(string $file, bool $debug = false): string
     {
         $content = \file_get_contents(__DIR__.'/Fixture/'.$file);
 

--- a/Tests/Unit/Twig/DefaultApplyingNodeVisitorTest.php
+++ b/Tests/Unit/Twig/DefaultApplyingNodeVisitorTest.php
@@ -16,7 +16,7 @@ namespace Translation\Bundle\Tests\Unit\Twig;
  */
 class DefaultApplyingNodeVisitorTest extends BaseTwigTestCase
 {
-    public function testApply()
+    public function testApply(): void
     {
         $this->assertEquals(
             $this->parse('apply_default_value_compiled.html.twig', true),

--- a/Tests/Unit/Twig/NormalizingNodeVisitorTest.php
+++ b/Tests/Unit/Twig/NormalizingNodeVisitorTest.php
@@ -16,7 +16,7 @@ namespace Translation\Bundle\Tests\Unit\Twig;
  */
 class NormalizingNodeVisitorTest extends BaseTwigTestCase
 {
-    public function testBinaryConcatOfConstants()
+    public function testBinaryConcatOfConstants(): void
     {
         $this->assertEquals(
             $this->parse('binary_concat_of_constants_compiled.html.twig'),

--- a/Tests/Unit/Twig/RemovingNodeVisitorTest.php
+++ b/Tests/Unit/Twig/RemovingNodeVisitorTest.php
@@ -16,7 +16,7 @@ namespace Translation\Bundle\Tests\Unit\Twig;
  */
 class RemovingNodeVisitorTest extends BaseTwigTestCase
 {
-    public function testRemovalWithSimpleTemplate()
+    public function testRemovalWithSimpleTemplate(): void
     {
         $expected = $this->parse('simple_template_compiled.html.twig');
         $actual = $this->parse('simple_template.html.twig');

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -12,6 +12,7 @@
 namespace Translation\Bundle\Translator;
 
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
@@ -24,17 +25,17 @@ use Translation\Bundle\EditInPlace\ActivatorInterface;
 final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagInterface
 {
     /**
-     * @var TranslatorInterface|\Symfony\Component\Translation\Translator
+     * @var \Symfony\Component\Translation\TranslatorInterface
      */
     private $translator;
 
     /**
-     * @var ActivatorInterface
+     * @var \Translation\Bundle\EditInPlace\ActivatorInterface
      */
     private $activator;
 
     /**
-     * @var RequestStack
+     * @var \Symfony\Component\HttpFoundation\RequestStack
      */
     private $requestStack;
 
@@ -48,7 +49,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
     /**
      * @see Translator::getCatalogue
      */
-    public function getCatalogue($locale = null)
+    public function getCatalogue($locale = null): MessageCatalogueInterface
     {
         return $this->translator->getCatalogue($locale);
     }
@@ -56,7 +57,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
     /**
      * @see Translator::trans
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): ?string
     {
         $original = $this->translator->trans($id, $parameters, $domain, $locale);
         if (!$this->activator->checkRequest($this->requestStack->getMasterRequest())) {
@@ -87,7 +88,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
     /**
      * @see Translator::trans
      */
-    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): ?string
     {
         if (!$this->activator->checkRequest($this->requestStack->getMasterRequest())) {
             return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
@@ -103,7 +104,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
     /**
      * @see Translator::trans
      */
-    public function setLocale($locale)
+    public function setLocale($locale): void
     {
         $this->translator->setLocale($locale);
     }
@@ -111,7 +112,7 @@ final class EditInPlaceTranslator implements TranslatorInterface, TranslatorBagI
     /**
      * @see Translator::trans
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->translator->getLocale();
     }

--- a/Translator/FallbackTranslator.php
+++ b/Translator/FallbackTranslator.php
@@ -38,9 +38,6 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
      */
     private $defaultLocale;
 
-    /**
-     * @param string $defaultLocale
-     */
     public function __construct(string $defaultLocale, TranslatorInterface $symfonyTranslator, Translator $externalTranslator)
     {
         $this->symfonyTranslator = $symfonyTranslator;
@@ -135,8 +132,6 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * @param string $orgString This is the string in the default locale. It has the values of $parameters in the string already.
      * @param string $locale    you wan to translate to
-     *
-     * @return string
      */
     private function translateWithSubstitutedParameters(string $orgString, string $locale, array $parameters): string
     {

--- a/Translator/FallbackTranslator.php
+++ b/Translator/FallbackTranslator.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Translator;
 
+use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Translation\Translator\Translator;
@@ -42,7 +43,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
      * @param TranslatorInterface $symfonyTranslator
      * @param Translator          $externalTranslator
      */
-    public function __construct($defaultLocale, TranslatorInterface $symfonyTranslator, Translator $externalTranslator)
+    public function __construct(string $defaultLocale, TranslatorInterface $symfonyTranslator, Translator $externalTranslator)
     {
         $this->symfonyTranslator = $symfonyTranslator;
         $this->externalTranslator = $externalTranslator;
@@ -52,7 +53,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * {@inheritdoc}
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         $id = (string) $id;
         if (empty($domain)) {
@@ -78,7 +79,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * {@inheritdoc}
      */
-    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): string
     {
         $id = (string) $id;
         if (empty($domain)) {
@@ -104,7 +105,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * {@inheritdoc}
      */
-    public function setLocale($locale)
+    public function setLocale($locale): void
     {
         $this->symfonyTranslator->setLocale($locale);
     }
@@ -112,7 +113,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->symfonyTranslator->getLocale();
     }
@@ -120,7 +121,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * {@inheritdoc}
      */
-    public function getCatalogue($locale = null)
+    public function getCatalogue($locale = null): MessageCatalogueInterface
     {
         return $this->symfonyTranslator->getCatalogue($locale);
     }
@@ -128,7 +129,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     /**
      * Passes through all unknown calls onto the translator object.
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         return \call_user_func_array([$this->symfonyTranslator, $method], $args);
     }
@@ -140,7 +141,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
      *
      * @return string
      */
-    private function translateWithSubstitutedParameters($orgString, $locale, array $parameters)
+    private function translateWithSubstitutedParameters(string $orgString, string $locale, array $parameters): string
     {
         // Replace parameters
         $replacements = [];

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -46,8 +46,6 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
 
     /**
      * Escape output if the EditInPlace is disabled.
-     *
-     * @return array
      */
     public function isSafe($node): array
     {

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -36,7 +36,7 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
     /**
      * {@inheritdoc}
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('trans', [$this, 'trans'], ['is_safe_callback' => [$this, 'isSafe']]),
@@ -49,7 +49,7 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
      *
      * @return array
      */
-    public function isSafe($node)
+    public function isSafe($node): array
     {
         return $this->activator->checkRequest($this->requestStack->getMasterRequest()) ? ['html'] : [];
     }
@@ -57,7 +57,7 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
     /**
      * @param ActivatorInterface $activator
      */
-    public function setActivator(ActivatorInterface $activator)
+    public function setActivator(ActivatorInterface $activator): void
     {
         $this->activator = $activator;
     }
@@ -65,7 +65,7 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
     /**
      * @param RequestStack $requestStack
      */
-    public function setRequestStack(RequestStack $requestStack)
+    public function setRequestStack(RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;
     }
@@ -73,7 +73,7 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return self::class;
     }

--- a/Twig/Node/Transchoice.php
+++ b/Twig/Node/Transchoice.php
@@ -22,7 +22,7 @@ class Transchoice extends AbstractExpression
         parent::__construct(['arguments' => $arguments], [], $lineno);
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler->raw(
             \sprintf(

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -47,7 +47,7 @@ final class TranslationExtension extends AbstractExtension
     /**
      * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('desc', [$this, 'desc']),
@@ -58,7 +58,7 @@ final class TranslationExtension extends AbstractExtension
     /**
      * @return array
      */
-    public function getNodeVisitors()
+    public function getNodeVisitors(): array
     {
         $visitors = [
             new NormalizingNodeVisitor(),
@@ -82,7 +82,7 @@ final class TranslationExtension extends AbstractExtension
      *
      * @return string
      */
-    public function transchoiceWithDefault($message, $defaultMessage, $count, array $arguments = [], $domain = null, $locale = null)
+    public function transchoiceWithDefault($message, $defaultMessage, $count, array $arguments = [], $domain = null, $locale = null): string
     {
         if (null === $domain) {
             $domain = 'messages';
@@ -115,7 +115,7 @@ final class TranslationExtension extends AbstractExtension
         return $v;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'php-translation';
     }

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -35,18 +35,12 @@ final class TranslationExtension extends AbstractExtension
      */
     private $debug;
 
-    /**
-     * @param bool $debug
-     */
-    public function __construct(TranslatorInterface $translator, $debug = false)
+    public function __construct(TranslatorInterface $translator, bool $debug = false)
     {
         $this->translator = $translator;
         $this->debug = $debug;
     }
 
-    /**
-     * @return array
-     */
     public function getFilters(): array
     {
         return [
@@ -55,9 +49,6 @@ final class TranslationExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @return array
-     */
     public function getNodeVisitors(): array
     {
         $visitors = [
@@ -72,16 +63,7 @@ final class TranslationExtension extends AbstractExtension
         return $visitors;
     }
 
-    /**
-     * @param string      $message
-     * @param string      $defaultMessage
-     * @param int         $count
-     * @param string|null $domain
-     * @param string|null $locale
-     *
-     * @return string
-     */
-    public function transchoiceWithDefault($message, $defaultMessage, $count, array $arguments = [], $domain = null, $locale = null): string
+    public function transchoiceWithDefault(string $message, string $defaultMessage, int $count, array $arguments = [], ?string $domain = null, ?string $locale = null): string
     {
         if (null === $domain) {
             $domain = 'messages';

--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -36,17 +36,11 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
      */
     private $enabled = true;
 
-    /**
-     * @param bool $bool
-     */
     public function setEnabled(bool $bool): void
     {
         $this->enabled = $bool;
     }
 
-    /**
-     * @return Node
-     */
     public function doEnterNode(Node $node, Environment $env): Node
     {
         if (!$this->enabled) {
@@ -120,17 +114,11 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return Node
-     */
     public function doLeaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return int
-     */
     public function getPriority(): int
     {
         return -2;

--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -39,9 +39,9 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
     /**
      * @param $bool
      */
-    public function setEnabled($bool)
+    public function setEnabled(bool $bool): void
     {
-        $this->enabled = (bool) $bool;
+        $this->enabled = $bool;
     }
 
     /**
@@ -50,7 +50,7 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
      *
      * @return Node
      */
-    public function doEnterNode(Node $node, Environment $env)
+    public function doEnterNode(Node $node, Environment $env): Node
     {
         if (!$this->enabled) {
             return $node;
@@ -129,7 +129,7 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
      *
      * @return Node
      */
-    public function doLeaveNode(Node $node, Environment $env)
+    public function doLeaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
@@ -137,7 +137,7 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -2;
     }

--- a/Twig/Visitor/NormalizingNodeVisitor.php
+++ b/Twig/Visitor/NormalizingNodeVisitor.php
@@ -27,9 +27,6 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
  */
 final class NormalizingNodeVisitor extends AbstractNodeVisitor
 {
-    /**
-     * @return Node
-     */
     protected function doEnterNode(Node $node, Environment $env): Node
     {
         return $node;
@@ -49,9 +46,6 @@ final class NormalizingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return int
-     */
     public function getPriority(): int
     {
         return -3;

--- a/Twig/Visitor/NormalizingNodeVisitor.php
+++ b/Twig/Visitor/NormalizingNodeVisitor.php
@@ -33,7 +33,7 @@ final class NormalizingNodeVisitor extends AbstractNodeVisitor
      *
      * @return Node
      */
-    protected function doEnterNode(Node $node, Environment $env)
+    protected function doEnterNode(Node $node, Environment $env): Node
     {
         return $node;
     }
@@ -44,7 +44,7 @@ final class NormalizingNodeVisitor extends AbstractNodeVisitor
      *
      * @return ConstantExpression|Node
      */
-    protected function doLeaveNode(Node $node, Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env): Node
     {
         if ($node instanceof ConcatBinary
             && ($left = $node->getNode('left')) instanceof ConstantExpression
@@ -58,7 +58,7 @@ final class NormalizingNodeVisitor extends AbstractNodeVisitor
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -3;
     }

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -28,17 +28,11 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
      */
     private $enabled = true;
 
-    /**
-     * @param bool $bool
-     */
     public function setEnabled(bool $bool): void
     {
         $this->enabled = $bool;
     }
 
-    /**
-     * @return Node
-     */
     protected function doEnterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
@@ -52,17 +46,11 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return Node
-     */
     protected function doLeaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return int
-     */
     public function getPriority(): int
     {
         return -1;

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -31,9 +31,9 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
     /**
      * @param $bool
      */
-    public function setEnabled($bool)
+    public function setEnabled(bool $bool): void
     {
-        $this->enabled = (bool) $bool;
+        $this->enabled = $bool;
     }
 
     /**
@@ -42,7 +42,7 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
      *
      * @return Node
      */
-    protected function doEnterNode(Node $node, Environment $env)
+    protected function doEnterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -61,7 +61,7 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
      *
      * @return Node
      */
-    protected function doLeaveNode(Node $node, Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
@@ -69,7 +69,7 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -1;
     }


### PR DESCRIPTION
As the package require PHP >= `7.1`, I added i/o type hinting when possible and replace some `isset()` call with the null coalescing operator