### PR TITLE
Fix codestyle after uptream release of cs-fixer

### DIFF
--- a/Catalogue/CatalogueCounter.php
+++ b/Catalogue/CatalogueCounter.php
@@ -23,8 +23,6 @@ use Translation\Bundle\Model\Metadata;
 class CatalogueCounter
 {
     /**
-     * @param MessageCatalogueInterface $catalogue
-     *
      * @return int
      */
     public function getNumberOfDefinedMessages(MessageCatalogueInterface $catalogue)
@@ -38,8 +36,6 @@ class CatalogueCounter
     }
 
     /**
-     * @param MessageCatalogueInterface $catalogue
-     *
      * @return array
      */
     public function getCatalogueStatistics(MessageCatalogueInterface $catalogue)

--- a/Catalogue/CatalogueFetcher.php
+++ b/Catalogue/CatalogueFetcher.php
@@ -49,9 +49,6 @@ final class CatalogueFetcher
     /**
      * load any existing messages from the translation files.
      *
-     * @param Configuration $config
-     * @param array         $locales
-     *
      * @return MessageCatalogue[]
      */
     public function getCatalogues(Configuration $config, array $locales = [])

--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -148,7 +148,6 @@ final class CatalogueManager
     }
 
     /**
-     * @param MessageCatalogueInterface $catalogue
      * @param $locale
      * @param $domain
      * @param $key

--- a/Catalogue/CatalogueWriter.php
+++ b/Catalogue/CatalogueWriter.php
@@ -37,8 +37,7 @@ final class CatalogueWriter
     private $defaultLocale;
 
     /**
-     * @param TranslationWriter $writer
-     * @param string            $defaultLocale
+     * @param string $defaultLocale
      */
     public function __construct(TranslationWriter $writer, $defaultLocale)
     {
@@ -51,7 +50,6 @@ final class CatalogueWriter
     }
 
     /**
-     * @param Configuration      $config
      * @param MessageCatalogue[] $catalogues
      */
     public function writeCatalogues(Configuration $config, array $catalogues)

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -48,12 +48,6 @@ class DeleteObsoleteCommand extends Command
      */
     private $catalogueFetcher;
 
-    /**
-     * @param StorageManager       $storageManager
-     * @param ConfigurationManager $configurationManager
-     * @param CatalogueManager     $catalogueManager
-     * @param CatalogueFetcher     $catalogueFetcher
-     */
     public function __construct(
         StorageManager $storageManager,
         ConfigurationManager $configurationManager,

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -41,11 +41,6 @@ class DownloadCommand extends Command
      */
     private $cacheCleaner;
 
-    /**
-     * @param StorageManager       $storageManager
-     * @param ConfigurationManager $configurationManager
-     * @param CacheClearer         $cacheCleaner
-     */
     public function __construct(
         StorageManager $storageManager,
         ConfigurationManager $configurationManager,

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -60,13 +60,6 @@ class ExtractCommand extends Command
      */
     private $configurationManager;
 
-    /**
-     * @param CatalogueFetcher     $catalogueFetcher
-     * @param CatalogueWriter      $catalogueWriter
-     * @param CatalogueCounter     $catalogueCounter
-     * @param Importer             $importer
-     * @param ConfigurationManager $configurationManager
-     */
     public function __construct(
         CatalogueFetcher $catalogueFetcher,
         CatalogueWriter $catalogueWriter,
@@ -141,8 +134,6 @@ class ExtractCommand extends Command
     }
 
     /**
-     * @param Configuration $config
-     *
      * @return Finder
      */
     private function getConfiguredFinder(Configuration $config)

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -45,11 +45,6 @@ class StatusCommand extends Command
      */
     private $catalogueFetcher;
 
-    /**
-     * @param CatalogueCounter     $catalogueCounter
-     * @param ConfigurationManager $configurationManager
-     * @param CatalogueFetcher     $catalogueFetcher
-     */
     public function __construct(
         CatalogueCounter $catalogueCounter,
         ConfigurationManager $configurationManager,

--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -27,9 +27,6 @@ class SyncCommand extends Command
 
     protected static $defaultName = 'translation:sync';
 
-    /**
-     * @param StorageManager $storageManager
-     */
     public function __construct(StorageManager $storageManager)
     {
         $this->storageManager = $storageManager;

--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -25,9 +25,8 @@ use Translation\Common\Model\MessageInterface;
 class EditInPlaceController extends Controller
 {
     /**
-     * @param Request $request
-     * @param string  $configName
-     * @param string  $locale
+     * @param string $configName
+     * @param string $locale
      *
      * @return Response
      */
@@ -54,9 +53,7 @@ class EditInPlaceController extends Controller
     /**
      * Get and validate messages from the request.
      *
-     * @param Request $request
-     * @param string  $locale
-     * @param array   $validationGroups
+     * @param string $locale
      *
      * @return MessageInterface[]
      *

--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -26,8 +26,7 @@ use Translation\Common\Model\MessageInterface;
 class SymfonyProfilerController extends Controller
 {
     /**
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return Response
      */
@@ -62,8 +61,7 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return Response
      */
@@ -86,8 +84,7 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param         $token
+     * @param $token
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
@@ -109,8 +106,7 @@ class SymfonyProfilerController extends Controller
      *
      * @author Damien Alexandre (damienalexandre)
      *
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return Response
      */
@@ -137,8 +133,7 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return SfProfilerMessage
      */
@@ -174,8 +169,7 @@ class SymfonyProfilerController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return MessageInterface[]
      */

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -125,10 +125,9 @@ class WebUIController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $configName
-     * @param string  $locale
-     * @param string  $domain
+     * @param string $configName
+     * @param string $locale
+     * @param string $domain
      *
      * @return Response
      */
@@ -153,12 +152,7 @@ class WebUIController extends Controller
         try {
             $storage->create($message);
         } catch (StorageException $e) {
-            throw new BadRequestHttpException(\sprintf(
-                'Key "%s" does already exist for "%s" on domain "%s".',
-                $message->getKey(),
-                $locale,
-                $domain
-            ), $e);
+            throw new BadRequestHttpException(\sprintf('Key "%s" does already exist for "%s" on domain "%s".', $message->getKey(), $locale, $domain), $e);
         }
 
         return $this->render('@Translation/WebUI/create.html.twig', [
@@ -167,10 +161,9 @@ class WebUIController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $configName
-     * @param string  $locale
-     * @param string  $domain
+     * @param string $configName
+     * @param string $locale
+     * @param string $domain
      *
      * @return Response
      */
@@ -197,10 +190,9 @@ class WebUIController extends Controller
     }
 
     /**
-     * @param Request $request
-     * @param string  $configName
-     * @param string  $locale
-     * @param string  $domain
+     * @param string $configName
+     * @param string $locale
+     * @param string $domain
      *
      * @return Response
      */
@@ -227,8 +219,6 @@ class WebUIController extends Controller
     }
 
     /**
-     * @param Request $request
-     *
      * @return MessageInterface
      */
     private function getMessageFromRequest(Request $request)
@@ -263,9 +253,6 @@ class WebUIController extends Controller
     }
 
     /**
-     * @param MessageInterface $message
-     * @param array            $validationGroups
-     *
      * @throws MessageValidationException
      */
     private function validateMessage(MessageInterface $message, array $validationGroups)

--- a/DependencyInjection/CompilerPass/ExtractorPass.php
+++ b/DependencyInjection/CompilerPass/ExtractorPass.php
@@ -28,8 +28,6 @@ class ExtractorPass implements CompilerPassInterface
     }
 
     /**
-     * @param ContainerBuilder $container
-     *
      * @return array type => Definition[]
      */
     private function getExtractors(ContainerBuilder $container)
@@ -57,7 +55,6 @@ class ExtractorPass implements CompilerPassInterface
     }
 
     /**
-     * @param ContainerBuilder $container
      * @param $extractors
      */
     private function addVisitors(ContainerBuilder $container, $extractors)

--- a/DependencyInjection/CompilerPass/StoragePass.php
+++ b/DependencyInjection/CompilerPass/StoragePass.php
@@ -58,8 +58,6 @@ class StoragePass implements CompilerPassInterface
     }
 
     /**
-     * @param ContainerBuilder $container
-     *
      * @return Definition
      */
     private function getDefinition(ContainerBuilder $container, $name)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -87,9 +87,6 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * @param ArrayNodeDefinition $root
-     */
     private function configsNode(ArrayNodeDefinition $root)
     {
         $container = $this->container;

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -86,9 +86,6 @@ class TranslationExtension extends Extension
 
     /**
      * Handle the config node to prepare the config manager.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      */
     private function handleConfigNode(ContainerBuilder $container, array $config)
     {
@@ -151,9 +148,6 @@ class TranslationExtension extends Extension
 
     /**
      * Handle config for WebUI.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      */
     private function enableWebUi(ContainerBuilder $container, array $config)
     {
@@ -175,9 +169,6 @@ class TranslationExtension extends Extension
 
     /**
      * Handle config for EditInPlace.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      */
     private function enableEditInPlace(ContainerBuilder $container, array $config)
     {
@@ -203,9 +194,6 @@ class TranslationExtension extends Extension
 
     /**
      * Handle config for Symfony Profiler.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      */
     private function enableSymfonyProfiler(ContainerBuilder $container, array $config)
     {
@@ -214,9 +202,6 @@ class TranslationExtension extends Extension
 
     /**
      * Handle config for fallback auto translate.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      */
     private function enableFallbackAutoTranslator(ContainerBuilder $container, array $config)
     {

--- a/EditInPlace/ActivatorInterface.php
+++ b/EditInPlace/ActivatorInterface.php
@@ -21,8 +21,6 @@ interface ActivatorInterface
     /**
      * Tells if the Edit In Place mode is enabled for this request.
      *
-     * @param Request|null $request
-     *
      * @return bool
      */
     public function checkRequest(Request $request = null);

--- a/EventListener/AutoAddMissingTranslations.php
+++ b/EventListener/AutoAddMissingTranslations.php
@@ -33,7 +33,6 @@ final class AutoAddMissingTranslations
 
     /**
      * @param DataCollectorTranslator $translator
-     * @param StorageService          $storage
      */
     public function __construct(StorageService $storage, DataCollectorTranslator $translator = null)
     {

--- a/Model/CatalogueMessage.php
+++ b/Model/CatalogueMessage.php
@@ -51,11 +51,10 @@ final class CatalogueMessage
     private $metadata;
 
     /**
-     * @param CatalogueManager $catalogueManager
-     * @param string           $locale
-     * @param string           $domain
-     * @param string           $key
-     * @param string           $message
+     * @param string $locale
+     * @param string $domain
+     * @param string $key
+     * @param string $message
      */
     public function __construct(CatalogueManager $catalogueManager, $locale, $domain, $key, $message)
     {

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -92,9 +92,6 @@ final class Configuration
      */
     private $xliffVersion;
 
-    /**
-     * @param array $data
-     */
     public function __construct(array $data)
     {
         $this->name = $data['name'];

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -83,8 +83,6 @@ final class SfProfilerMessage
     private $parameters;
 
     /**
-     * @param array $data
-     *
      * @return SfProfilerMessage
      */
     public static function create(array $data)

--- a/Service/ConfigurationManager.php
+++ b/Service/ConfigurationManager.php
@@ -26,8 +26,7 @@ final class ConfigurationManager
     private $configuration = [];
 
     /**
-     * @param string        $name
-     * @param Configuration $configuration
+     * @param string $name
      */
     public function addConfiguration($name, Configuration $configuration)
     {

--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -51,9 +51,7 @@ final class Importer
     private $defaultLocale;
 
     /**
-     * @param Extractor   $extractor
-     * @param Environment $twig
-     * @param string      $defaultLocale
+     * @param string $defaultLocale
      */
     public function __construct(Extractor $extractor, Environment $twig, $defaultLocale)
     {
@@ -63,7 +61,6 @@ final class Importer
     }
 
     /**
-     * @param Finder             $finder
      * @param MessageCatalogue[] $catalogues
      * @param array              $config     {
      *
@@ -128,10 +125,6 @@ final class Importer
         return new ImportResult($results, $sourceCollection->getErrors());
     }
 
-    /**
-     * @param MessageCatalogue $catalogue
-     * @param SourceCollection $collection
-     */
     private function convertSourceLocationsToMessages(MessageCatalogue $catalogue, SourceCollection $collection)
     {
         /** @var SourceLocation $sourceLocation */
@@ -160,7 +153,6 @@ final class Importer
     }
 
     /**
-     * @param MessageCatalogue $catalogue
      * @param $key
      * @param $domain
      *
@@ -172,10 +164,8 @@ final class Importer
     }
 
     /**
-     * @param MessageCatalogue $catalogue
      * @param $key
      * @param $domain
-     * @param Metadata $metadata
      */
     private function setMetadata(MessageCatalogue $catalogue, $key, $domain, Metadata $metadata)
     {

--- a/Service/StorageManager.php
+++ b/Service/StorageManager.php
@@ -24,8 +24,7 @@ final class StorageManager
     private $storages = [];
 
     /**
-     * @param string         $name
-     * @param StorageService $storage
+     * @param string $name
      */
     public function addStorage($name, StorageService $storage)
     {

--- a/Service/StorageService.php
+++ b/Service/StorageService.php
@@ -57,11 +57,6 @@ final class StorageService implements Storage
      */
     private $config;
 
-    /**
-     * @param CatalogueFetcher $catalogueFetcher
-     * @param CatalogueWriter  $catalogueWriter
-     * @param Configuration    $config
-     */
     public function __construct(
         CatalogueFetcher $catalogueFetcher,
         CatalogueWriter $catalogueWriter,
@@ -238,8 +233,7 @@ final class StorageService implements Storage
     }
 
     /**
-     * @param Storage[]        $storages
-     * @param MessageInterface $message
+     * @param Storage[] $storages
      */
     private function updateStorages(array $storages, MessageInterface $message)
     {
@@ -269,8 +263,6 @@ final class StorageService implements Storage
     }
 
     /**
-     * @param Storage $localStorage
-     *
      * @return StorageService
      */
     public function addLocalStorage(Storage $localStorage)
@@ -281,8 +273,6 @@ final class StorageService implements Storage
     }
 
     /**
-     * @param Storage $remoteStorage
-     *
      * @return StorageService
      */
     public function addRemoteStorage(Storage $remoteStorage)

--- a/Translator/FallbackTranslator.php
+++ b/Translator/FallbackTranslator.php
@@ -38,9 +38,7 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     private $defaultLocale;
 
     /**
-     * @param string              $defaultLocale
-     * @param TranslatorInterface $symfonyTranslator
-     * @param Translator          $externalTranslator
+     * @param string $defaultLocale
      */
     public function __construct($defaultLocale, TranslatorInterface $symfonyTranslator, Translator $externalTranslator)
     {
@@ -134,9 +132,8 @@ final class FallbackTranslator implements TranslatorInterface, TranslatorBagInte
     }
 
     /**
-     * @param string $orgString  This is the string in the default locale. It has the values of $parameters in the string already.
-     * @param string $locale     you wan to translate to
-     * @param array  $parameters
+     * @param string $orgString This is the string in the default locale. It has the values of $parameters in the string already.
+     * @param string $locale    you wan to translate to
      *
      * @return string
      */

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -54,17 +54,11 @@ final class EditInPlaceExtension extends \Symfony\Bridge\Twig\Extension\Translat
         return $this->activator->checkRequest($this->requestStack->getMasterRequest()) ? ['html'] : [];
     }
 
-    /**
-     * @param ActivatorInterface $activator
-     */
     public function setActivator(ActivatorInterface $activator)
     {
         $this->activator = $activator;
     }
 
-    /**
-     * @param RequestStack $requestStack
-     */
     public function setRequestStack(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -35,8 +35,7 @@ final class TranslationExtension extends AbstractExtension
     private $debug;
 
     /**
-     * @param TranslatorInterface $translator
-     * @param bool                $debug
+     * @param bool $debug
      */
     public function __construct(TranslatorInterface $translator, $debug = false)
     {
@@ -76,7 +75,6 @@ final class TranslationExtension extends AbstractExtension
      * @param string      $message
      * @param string      $defaultMessage
      * @param int         $count
-     * @param array       $arguments
      * @param string|null $domain
      * @param string|null $locale
      *

--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -45,9 +45,6 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
     }
 
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return Node
      */
     public function doEnterNode(Node $node, Environment $env)
@@ -124,9 +121,6 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
     }
 
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return Node
      */
     public function doLeaveNode(Node $node, Environment $env)

--- a/Twig/Visitor/NormalizingNodeVisitor.php
+++ b/Twig/Visitor/NormalizingNodeVisitor.php
@@ -28,9 +28,6 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
 final class NormalizingNodeVisitor extends AbstractNodeVisitor
 {
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return Node
      */
     protected function doEnterNode(Node $node, Environment $env)
@@ -39,9 +36,6 @@ final class NormalizingNodeVisitor extends AbstractNodeVisitor
     }
 
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return ConstantExpression|Node
      */
     protected function doLeaveNode(Node $node, Environment $env)

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -37,9 +37,6 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
     }
 
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return Node
      */
     protected function doEnterNode(Node $node, Environment $env)
@@ -56,9 +53,6 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
     }
 
     /**
-     * @param Node        $node
-     * @param Environment $env
-     *
      * @return Node
      */
     protected function doLeaveNode(Node $node, Environment $env)


### PR DESCRIPTION
The default CS-Fixer configurations for `@Symfony` has been updated.

See related comments from https://github.com/php-translation/symfony-bundle/pull/342#issuecomment-549740795 until https://github.com/php-translation/symfony-bundle/pull/342#issuecomment-549928172


If wanted we can also add the related `Makefile` to this PR:

```make
# Makefile

DIR := ${CURDIR}

phpstan:
	docker run --rm -v $(DIR):/project -w /project jakzal/phpqa:php7.1-alpine phpstan analyze

codestyle:
	docker run --rm -v $(DIR):/project -w /project jakzal/phpqa:php7.1-alpine php-cs-fixer fix
```