### PR TITLE
Add command to delete empty messages

### DIFF
--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -82,6 +82,7 @@ final class CatalogueManager
         $isNew = $config['isNew'] ?? null;
         $isObsolete = $config['isObsolete'] ?? null;
         $isApproved = $config['isApproved'] ?? null;
+        $isEmpty = $config['isEmpty'] ?? null;
 
         $messages = [];
         $catalogues = [];
@@ -106,7 +107,7 @@ final class CatalogueManager
             }
         }
 
-        $messages = \array_filter($messages, static function (CatalogueMessage $m) use ($isNew, $isObsolete, $isApproved) {
+        $messages = \array_filter($messages, static function (CatalogueMessage $m) use ($isNew, $isObsolete, $isApproved, $isEmpty) {
             if (null !== $isNew && $m->isNew() !== $isNew) {
                 return false;
             }
@@ -114,6 +115,9 @@ final class CatalogueManager
                 return false;
             }
             if (null !== $isApproved && $m->isApproved() !== $isApproved) {
+                return false;
+            }
+            if (null !== $isEmpty && empty($m->getMessage()) !== $isEmpty) {
                 return false;
             }
 

--- a/Command/DeleteEmptyCommand.php
+++ b/Command/DeleteEmptyCommand.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Translation\Bundle\Catalogue\CatalogueFetcher;
+use Translation\Bundle\Catalogue\CatalogueManager;
+use Translation\Bundle\Service\ConfigurationManager;
+use Translation\Bundle\Service\StorageManager;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DeleteEmptyCommand extends Command
+{
+    use BundleTrait;
+    use StorageTrait;
+
+    protected static $defaultName = 'translation:delete-empty';
+
+    /**
+     * @var ConfigurationManager
+     */
+    private $configurationManager;
+
+    /**
+     * @var CatalogueManager
+     */
+    private $catalogueManager;
+
+    /**
+     * @var CatalogueFetcher
+     */
+    private $catalogueFetcher;
+
+    public function __construct(
+        StorageManager $storageManager,
+        ConfigurationManager $configurationManager,
+        CatalogueManager $catalogueManager,
+        CatalogueFetcher $catalogueFetcher
+    ) {
+        $this->storageManager = $storageManager;
+        $this->configurationManager = $configurationManager;
+        $this->catalogueManager = $catalogueManager;
+        $this->catalogueFetcher = $catalogueFetcher;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName(self::$defaultName)
+            ->setDescription('Delete all translations currently empty.')
+            ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
+            ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to use. If omitted, we use all configured locales.', null)
+            ->addOption('bundle', 'b', InputOption::VALUE_REQUIRED, 'The bundle you want remove translations from.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $configName = $input->getArgument('configuration');
+        $locales = [];
+        if (null !== $inputLocale = $input->getArgument('locale')) {
+            $locales = [$inputLocale];
+        }
+
+        $config = $this->configurationManager->getConfiguration($configName);
+        $this->configureBundleDirs($input, $config);
+        $this->catalogueManager->load($this->catalogueFetcher->getCatalogues($config, $locales));
+
+        $storage = $this->getStorage($configName);
+        $messages = $this->catalogueManager->findMessages(['locale' => $inputLocale, 'isEmpty' => true]);
+
+        $messageCount = \count($messages);
+        if (0 === $messageCount) {
+            $output->writeln('No messages are empty');
+
+            return 0;
+        }
+
+        if ($input->isInteractive()) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(\sprintf('You are about to remove %d translations. Do you wish to continue? (y/N) ', $messageCount), false);
+            if (!$helper->ask($input, $output, $question)) {
+                return 0;
+            }
+        }
+
+        $progress = null;
+        if (OutputInterface::VERBOSITY_NORMAL === $output->getVerbosity() && OutputInterface::VERBOSITY_QUIET !== $output->getVerbosity()) {
+            $progress = new ProgressBar($output, $messageCount);
+        }
+        foreach ($messages as $message) {
+            $storage->delete($message->getLocale(), $message->getDomain(), $message->getKey());
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+                $output->writeln(\sprintf(
+                    'Deleted empty message "<info>%s</info>" from domain "<info>%s</info>" and locale "<info>%s</info>"',
+                    $message->getKey(),
+                    $message->getDomain(),
+                    $message->getLocale()
+                ));
+            }
+
+            if ($progress) {
+                $progress->advance();
+            }
+        }
+
+        if ($progress) {
+            $progress->finish();
+        }
+
+        return 0;
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,6 +3,11 @@ parameters:
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Application\\:\\:getKernel\\(\\)\\.$#"
 			count: 1
+			path: Command/DeleteEmptyCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Application\\:\\:getKernel\\(\\)\\.$#"
+			count: 1
 			path: Command/DeleteObsoleteCommand.php
 
 		-


### PR DESCRIPTION
translation:extract on a new lang currently export keys with empty string as translation, resulting in empty string being valid translations.
I prefer to delete empty translations than having empty string, so fallback can be used