### PR TITLE
Deal with Translator interface coming from component (3.4) & contract…

### DIFF
--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -15,15 +15,32 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface as NewTranslatorInterface;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
 use Translation\Bundle\Translator\EditInPlaceTranslator;
+use Translation\Bundle\Translator\TranslatorInterface;
 
 /**
  * @author Damien Alexandre <dalexandre@jolicode.com>
  */
 final class EditInPlaceTranslatorTest extends TestCase
 {
+    public function testWithNotLocaleAwareTranslator()
+    {
+        if (!\interface_exists(NewTranslatorInterface::class)) {
+            $this->markTestSkipped('Relevant only when NewTranslatorInterface is available.');
+        }
+
+        $symfonyTranslator = $this->getMockBuilder(NewTranslatorInterface::class)->getMock();
+        $activator = new FakeActivator(true);
+        $requestStack = new RequestStack();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given translator must implements LocaleAwareInterface.');
+
+        new EditInPlaceTranslator($symfonyTranslator, $activator, $requestStack);
+    }
+
     public function testEnabled(): void
     {
         $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();

--- a/Tests/Unit/Translator/FallbackTranslatorTest.php
+++ b/Tests/Unit/Translator/FallbackTranslatorTest.php
@@ -13,8 +13,9 @@ namespace Translation\Bundle\Tests\Unit\Translator;
 
 use Nyholm\NSA;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface as NewTranslatorInterface;
 use Translation\Bundle\Translator\FallbackTranslator;
+use Translation\Bundle\Translator\TranslatorInterface;
 use Translation\Translator\Translator;
 use Translation\Translator\TranslatorService;
 
@@ -23,6 +24,21 @@ use Translation\Translator\TranslatorService;
  */
 final class FallbackTranslatorTest extends TestCase
 {
+    public function testWithNotLocaleAwareTranslator()
+    {
+        if (!\interface_exists(NewTranslatorInterface::class)) {
+            $this->markTestSkipped('Relevant only when NewTranslatorInterface is available.');
+        }
+
+        $symfonyTranslator = $this->getMockBuilder(NewTranslatorInterface::class)->getMock();
+        $translator = new Translator();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given translator must implements LocaleAwareInterface.');
+
+        new FallbackTranslator('en', $symfonyTranslator, $translator);
+    }
+
     public function testTranslateWithSubstitutedParameters(): void
     {
         $symfonyTranslator = $this->getMockBuilder(TranslatorInterface::class)->getMock();

--- a/Translator/TranslatorInterface.php
+++ b/Translator/TranslatorInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Translator;
+
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Contracts\Translation\TranslatorInterface as NewTranslatorInterface;
+
+/*
+ * This interface is here to allow us to support both sf 3.x with
+ * LegacyTranslatorInterface & sf 5.x where this interface have been replaced
+ * by NewLocalAwareInterface.
+ *
+ * When sf 3.4 won't be supported anymore, this interface will become useless.
+ */
+
+if (\interface_exists(NewTranslatorInterface::class)) {
+    interface TranslatorInterface extends NewTranslatorInterface, LocaleAwareInterface, TranslatorBagInterface
+    {
+    }
+} else {
+    interface TranslatorInterface extends LegacyTranslatorInterface, TranslatorBagInterface
+    {
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,3 +39,7 @@ parameters:
         -
             path: %currentWorkingDirectory%/DependencyInjection/Configuration.php
             message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root()#'
+
+        -
+            path: %currentWorkingDirectory%/Translator
+            message: '#Call to an undefined method Symfony\\Component\\Translation\\TranslatorInterface|Symfony\\Contracts\\Translation\\TranslatorInterface::getCatalogue().#'


### PR DESCRIPTION
The `TranslatorInterface` located in the translation component will be removed in 5.x, replace by the `TranslatorInterface` located in contracts.

This PR allow us to deal with both `TranslatorInterface`.