### PR TITLE
Move Exception into getConfiguration method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /phpunit.xml
 /vendor/
 .php_cs.cache
+.phpunit.result.cache

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -80,9 +80,7 @@ class DeleteObsoleteCommand extends Command
             $locales = [$inputLocale];
         }
 
-        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
-            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
-        }
+        $config = $this->configurationManager->getConfiguration($configName);
 
         $this->configureBundleDirs($input, $config);
         $this->catalogueManager->load($this->catalogueFetcher->getCatalogues($config, $locales));

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -66,16 +66,13 @@ class DownloadCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configName = $input->getArgument('configuration');
+        $config = $this->configurationManager->getConfiguration($configName);
         $storage = $this->getStorage($configName);
 
-        if (null === $configuration = $this->configurationManager->getConfiguration($configName)) {
-            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
-        }
-
-        $this->configureBundleDirs($input, $configuration);
+        $this->configureBundleDirs($input, $config);
 
         if ($input->getOption('cache')) {
-            $translationsDirectory = $configuration->getOutputDir();
+            $translationsDirectory = $config->getOutputDir();
             $md5BeforeDownload = $this->hashDirectory($translationsDirectory);
             $storage->download();
             $md5AfterDownload = $this->hashDirectory($translationsDirectory);

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -91,9 +91,7 @@ class ExtractCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configName = $input->getArgument('configuration');
-        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
-            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
-        }
+        $config = $this->configurationManager->getConfiguration($configName);
 
         $locales = [];
         if ($inputLocale = $input->getArgument('locale')) {

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -72,9 +72,7 @@ class StatusCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configName = $input->getArgument('configuration');
-        if (null === $config = $this->configurationManager->getConfiguration($configName)) {
-            throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $configName));
-        }
+        $config = $this->configurationManager->getConfiguration($configName);
 
         $this->configureBundleDirs($input, $config);
 

--- a/Service/ConfigurationManager.php
+++ b/Service/ConfigurationManager.php
@@ -33,7 +33,7 @@ final class ConfigurationManager
     /**
      * @param string|string[]|null $name
      */
-    public function getConfiguration($name = null): ?Configuration
+    public function getConfiguration($name = null): Configuration
     {
         if (empty($name)) {
             return $this->getConfiguration('default');
@@ -50,7 +50,7 @@ final class ConfigurationManager
             }
         }
 
-        return null;
+        throw new \InvalidArgumentException(\sprintf('No configuration found for "%s"', $name));
     }
 
     public function getFirstName(): ?string

--- a/Tests/Unit/Service/ConfigurationManagerTest.php
+++ b/Tests/Unit/Service/ConfigurationManagerTest.php
@@ -52,7 +52,10 @@ class ConfigurationManagerTest extends TestCase
         $manager->addConfiguration('bar', $this->createConfiguration());
         $manager->addConfiguration('default', $correctConfiguration);
 
-        $this->assertNull($manager->getConfiguration('missing'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No configuration found for "missing"');
+
+        $manager->getConfiguration('missing');
     }
 
     public function testFirstName(): void

--- a/TranslationBundle.php
+++ b/TranslationBundle.php
@@ -27,7 +27,7 @@ use Translation\Bundle\DependencyInjection\CompilerPass\ValidatorVisitorPass;
  */
 class TranslationBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SymfonyProfilerPass());
         $container->addCompilerPass(new ValidatorVisitorPass());


### PR DESCRIPTION
Exception on missing configuration was only thrown when using a command. This fix that by moving Exception directly into `getConfiguration()` method which is also called in `WebUIController` 