### PR TITLE
Use specific tags instead of autoconfigure

### DIFF
--- a/Resources/config/edit_in_place.yaml
+++ b/Resources/config/edit_in_place.yaml
@@ -1,8 +1,8 @@
 services:
   Translation\Bundle\Controller\EditInPlaceController:
     autowire: true
-    autoconfigure: true
     public: true
+    tags: ['controller.service_arguments']
     arguments:
       - '@Translation\Bundle\Service\StorageManager'
       - '@Translation\Bundle\Service\CacheClearer'

--- a/Resources/config/webui.yaml
+++ b/Resources/config/webui.yaml
@@ -1,8 +1,8 @@
 services:
     Translation\Bundle\Controller\WebUIController:
         autowire: true
-        autoconfigure: true
         public: true
+        tags: ['controller.service_arguments']
         arguments:
             - '@Translation\Bundle\Service\ConfigurationManager'
             - '@Translation\Bundle\Catalogue\CatalogueFetcher'


### PR DESCRIPTION
Lets be specific, there is no need to trust/hope that the user has configured the correct compiler passes. 