### PR TITLE
Do not force minimum stabilty anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml Tests/Unit"
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "0.10-dev"


### PR DESCRIPTION
Not needed as extractor 2.0 have been released.