### PR TITLE
Add support for arbitrary options to StorageInterface::export()/import()

### DIFF
--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -42,8 +42,8 @@ class SyncCommand extends Command
             ->setDescription('Sync the translations with the remote storage')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('direction', InputArgument::OPTIONAL, 'Use "down" if local changes should be overwritten, otherwise "up"', 'down')
-            ->addOption('export-config', 'exconf', InputOption::VALUE_IS_ARRAY, 'Options to send to the StorageInterface::export() function. Ie, when downloading. Example: --export-conf foo:bar', [])
-            ->addOption('import-config', 'imconf', InputOption::VALUE_IS_ARRAY, 'Options to send to the StorageInterface::import() function. Ie, when uploading. Example: --import-conf foo:bar', [])
+            ->addOption('export-config', 'exconf', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Options to send to the StorageInterface::export() function. Ie, when downloading. Example: --export-config foo:bar', [])
+            ->addOption('import-config', 'imconf', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Options to send to the StorageInterface::import() function. Ie, when uploading. Example: --import-config foo:bar', [])
         ;
     }
 

--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -14,6 +14,7 @@ namespace Translation\Bundle\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Translation\Bundle\Service\StorageManager;
 use Translation\Bundle\Service\StorageService;
@@ -40,7 +41,10 @@ class SyncCommand extends Command
             ->setName(self::$defaultName)
             ->setDescription('Sync the translations with the remote storage')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
-            ->addArgument('direction', InputArgument::OPTIONAL, 'Use "down" if local changes should be overwritten, otherwise "up"', 'down');
+            ->addArgument('direction', InputArgument::OPTIONAL, 'Use "down" if local changes should be overwritten, otherwise "up"', 'down')
+            ->addOption('export-config', 'exconf', InputOption::VALUE_IS_ARRAY, 'Options to send to the StorageInterface::export() function. Ie, when downloading. Example: --export-conf foo:bar', [])
+            ->addOption('import-config', 'imconf', InputOption::VALUE_IS_ARRAY, 'Options to send to the StorageInterface::import() function. Ie, when uploading. Example: --import-conf foo:bar', [])
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -60,8 +64,24 @@ class SyncCommand extends Command
                 return 0;
         }
 
-        $this->getStorage($input->getArgument('configuration'))->sync($direction);
+        $export = $this->cleanParameters($input->getOption('export-config'));
+        $import = $this->cleanParameters($input->getOption('import-config'));
+
+        $this->getStorage($input->getArgument('configuration'))->sync($direction, $import, $export);
 
         return 0;
+    }
+
+    public function cleanParameters(array $raw)
+    {
+        $config = [];
+
+        foreach ($raw as $string) {
+            // Assert $string looks like "foo:bar"
+            list($key, $value) = \explode(':', $string, 2);
+            $config[$key][] = $value;
+        }
+
+        return $config;
     }
 }


### PR DESCRIPTION
This will partly fix #326 

Are the names `import-conf`/`export-conf` good enough? Should they be replaced with `download/upload`? (export = download, since the function is on the StorageInterface, exporting from a storage is taking things out of it...) 

