### PR TITLE
Resolve environment placeholders

### DIFF
--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -94,6 +94,7 @@ class TranslationExtension extends Extension
      */
     private function handleConfigNode(ContainerBuilder $container, array $config): void
     {
+        $container->resolveEnvPlaceholders($config);
         $storageManager = $container->getDefinition(StorageManager::class);
         $configurationManager = $container->getDefinition(ConfigurationManager::class);
         // $first will be the "default" configuration.


### PR DESCRIPTION
When using environment variables as values for config parameters that are read conditionally, symfony can mark that environment variable as unused and throw a fatal error.

For example, the following config:
```
translation:
    fallback_translation:
        enabled: '%env(bool:FALLBACK_TRANSLATION_ENABLED)%'
```
Will result in a fatal error if the environment variable is not used elsewhere. `Environment variables "bool:FALLBACK_TRANSLATION_ENABLED" are never used. Please, check your container's configuration.`

This PR solves this issue, see https://github.com/symfony/symfony/issues/23520#issuecomment-336167214 and the comment below that.