### PR TITLE
Configure bundle dir before fetching catalogues

### DIFF
--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -58,7 +58,7 @@ final class CatalogueManager
         }
 
         foreach ($this->catalogues[$locale]->all($domain) as $key => $text) {
-            $messages[] = $this->createMessage($this->catalogues[$locale], $locale, $domain, $key, $text);
+            $messages[] = $this->createMessage($this->catalogues[$locale], $locale, $domain, $key, $text ?? '');
         }
 
         return $messages;

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -98,8 +98,8 @@ class ExtractCommand extends Command
             $locales = [$inputLocale];
         }
 
-        $catalogues = $this->catalogueFetcher->getCatalogues($config, $locales);
         $this->configureBundleDirs($input, $config);
+        $catalogues = $this->catalogueFetcher->getCatalogues($config, $locales);
         $finder = $this->getConfiguredFinder($config);
 
         $result = $this->importer->extractToCatalogues($finder, $catalogues, [


### PR DESCRIPTION
This fixes the problem that catalogues are read from the "main" translation directory when extracting messages only for a specific bundle. The effect of this change is that messages from the main configuration are not entirely copied into the bundle being processed.

The second commit fixes another problem: when using the YAML format it may happen that the initial translation is `null` instead of an empty string. The `createMessage()` method expects a string argument though.