### PR TITLE
Simplify extractor service configuration

### DIFF
--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -42,6 +42,8 @@ class TranslationExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $container->setParameter('extractor_vendor_dir', $this->getExtractorVendorDirectory());
+
         $configuration = new Configuration($container);
         $config = $this->processConfiguration($configuration, $configs);
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
@@ -231,5 +233,12 @@ class TranslationExtension extends Extension
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container);
+    }
+
+    private function getExtractorVendorDirectory(): string
+    {
+        $vendorReflection = new \ReflectionClass(FormTypeChoices::class);
+
+        return dirname($vendorReflection->getFileName(), 4);
     }
 }

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -239,6 +239,6 @@ class TranslationExtension extends Extension
     {
         $vendorReflection = new \ReflectionClass(FormTypeChoices::class);
 
-        return dirname($vendorReflection->getFileName(), 4);
+        return \dirname($vendorReflection->getFileName(), 4);
     }
 }

--- a/Resources/config/extractors.yaml
+++ b/Resources/config/extractors.yaml
@@ -1,6 +1,8 @@
 services:
     _defaults:
         autowire: true
+        bind:
+            $metadataFactory: '@validator'
 
     _instanceof:
         PhpParser\NodeVisitor:
@@ -16,27 +18,8 @@ services:
             - { name: 'php_translation.extractor', type: 'twig' }
 
     # PHP Visitors:
-    Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTransChoice: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FlashMessage: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeEmptyValue: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelExplicit: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelImplicit: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\FormTypePlaceholder: ~
-
-    Translation\Extractor\Visitor\Php\Symfony\ValidationAnnotation: ~
+    Translation\Extractor\Visitor\Php\Symfony\:
+        resource: "%extractor_vendor_dir%/Visitor/Php/Symfony/*"
 
     Translation\Extractor\Visitor\Php\SourceLocationContainerVisitor: ~
 

--- a/Resources/config/extractors.yaml
+++ b/Resources/config/extractors.yaml
@@ -45,49 +45,49 @@ services:
         tags:
             - { name: 'php_translation.visitor', type: 'twig' }
 
-  # To remove in next major release
-  php_translation.extractor.php:
-    parent: Translation\Extractor\FileExtractor\PHPFileExtractor
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.twig:
-    parent: Translation\Extractor\FileExtractor\TwigFileExtractor
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.ContainerAwareTrans:
-    parent: Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.ContainerAwareTransChoice:
-    parent: Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTransChoice
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FlashMessage:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FlashMessage
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeChoices:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeEmptyValue:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeEmptyValue
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeHelp:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeInvalidMessage:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeLabelExplicit:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelExplicit
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypeLabelImplicit:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelImplicit
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.FormTypePlaceholder:
-    parent: Translation\Extractor\Visitor\Php\Symfony\FormTypePlaceholder
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.ValidationAnnotation:
-    parent: Translation\Extractor\Visitor\Php\Symfony\ValidationAnnotation
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.php.visitor.SourceLocationContainerVisitor:
-    parent: Translation\Extractor\Visitor\Php\SourceLocationContainerVisitor
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
-  php_translation.extractor.twig.factory.twig:
-    parent: Translation\Extractor\Visitor\Twig\TwigVisitor
-    deprecated: 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.'
+    # To remove in next major release
+    php_translation.extractor.php:
+        alias: Translation\Extractor\FileExtractor\PHPFileExtractor
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.twig:
+        alias: Translation\Extractor\FileExtractor\TwigFileExtractor
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.ContainerAwareTrans:
+        alias: Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.ContainerAwareTransChoice:
+        alias: Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTransChoice
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FlashMessage:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FlashMessage
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeChoices:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeEmptyValue:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeEmptyValue
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeHelp:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeInvalidMessage:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeLabelExplicit:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelExplicit
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypeLabelImplicit:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelImplicit
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.FormTypePlaceholder:
+        alias: Translation\Extractor\Visitor\Php\Symfony\FormTypePlaceholder
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.ValidationAnnotation:
+        alias: Translation\Extractor\Visitor\Php\Symfony\ValidationAnnotation
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.php.visitor.SourceLocationContainerVisitor:
+        alias: Translation\Extractor\Visitor\Php\SourceLocationContainerVisitor
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'
+    php_translation.extractor.twig.factory.twig:
+        alias: Translation\Extractor\Visitor\Twig\TwigVisitor
+        deprecated: 'The "%service_id%" service is deprecated. You should use "%alias_id%" instead, as it will be removed in the future.'

--- a/Resources/config/extractors.yaml
+++ b/Resources/config/extractors.yaml
@@ -1,67 +1,49 @@
 services:
-  Translation\Extractor\FileExtractor\PHPFileExtractor:
-    tags:
-      - { name: 'php_translation.extractor', type: 'php' }
+    _defaults:
+        autowire: true
 
-  Translation\Extractor\FileExtractor\TwigFileExtractor:
-    arguments: ["@twig"]
-    tags:
-      - { name: 'php_translation.extractor', type: 'twig' }
+    _instanceof:
+        PhpParser\NodeVisitor:
+            tags:
+                - { name: 'php_translation.visitor', type: 'php' }
 
-  # PHP Visitors:
-  Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\FileExtractor\PHPFileExtractor:
+        tags:
+            - { name: 'php_translation.extractor', type: 'php' }
 
-  Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTransChoice:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\FileExtractor\TwigFileExtractor:
+        tags:
+            - { name: 'php_translation.extractor', type: 'twig' }
 
-  Translation\Extractor\Visitor\Php\Symfony\FlashMessage:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    # PHP Visitors:
+    Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTransChoice: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeEmptyValue:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FlashMessage: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeEmptyValue: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelExplicit:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelImplicit:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeInvalidMessage: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\FormTypePlaceholder:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelExplicit: ~
 
-  Translation\Extractor\Visitor\Php\Symfony\ValidationAnnotation:
-    arguments: ['@validator']
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypeLabelImplicit: ~
 
-  Translation\Extractor\Visitor\Php\SourceLocationContainerVisitor:
-    tags:
-      - { name: 'php_translation.visitor', type: 'php' }
+    Translation\Extractor\Visitor\Php\Symfony\FormTypePlaceholder: ~
 
-  # Twig Visitors:
-  Translation\Extractor\Visitor\Twig\TwigVisitor:
-    tags:
-        - { name: 'php_translation.visitor', type: 'twig' }
+    Translation\Extractor\Visitor\Php\Symfony\ValidationAnnotation: ~
+
+    Translation\Extractor\Visitor\Php\SourceLocationContainerVisitor: ~
+
+    # Twig Visitors:
+    Translation\Extractor\Visitor\Twig\TwigVisitor:
+        tags:
+            - { name: 'php_translation.visitor', type: 'twig' }
 
   # To remove in next major release
   php_translation.extractor.php:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: Command/StatusCommand.php
 
 		-
-			message: "#^Call to method getValue\\(\\) on an unknown class Symfony\\\\Component\\\\Translation\\\\DataCollector\\\\Data\\.$#"
-			count: 1
-			path: Controller/SymfonyProfilerController.php
-
-		-
 			message: "#^Call to an undefined static method Symfony\\\\Component\\\\Intl\\\\Intl\\:\\:getLocaleBundle\\(\\)\\.$#"
 			count: 1
 			path: Controller/WebUIController.php


### PR DESCRIPTION
see https://github.com/php-translation/symfony-bundle/pull/395#discussion_r369983647

replaces #395 

* import directory over relying on adding extractor service configuration
* tag all imported services at once based on interface
* fix deprecated services, use alias instead of extending parent