### PR TITLE
allow null values in CheckMissingCommand

### DIFF
--- a/Command/CheckMissingCommand.php
+++ b/Command/CheckMissingCommand.php
@@ -134,8 +134,8 @@ final class CheckMissingCommand extends Command
         foreach ($catalogue->getDomains() as $domain) {
             $emptyTranslations = \array_filter(
                 $catalogue->all($domain),
-                function (string $message): bool {
-                    return '' === $message;
+                function (string $message = null): bool {
+                    return null === $message || '' === $message;
                 }
             );
 


### PR DESCRIPTION
This PR ensures that `translation:check-missing` does not break if a null value is given to the closure used in `countEmptyTranslations` method.

Error message:

```
In CheckMissingCommand.php line 137:
                                                                               
Argument 1 passed to Translation\Bundle\Command\CheckMissingCommand::Translation\Bundle\Command\{closure}() must be of the type string, null given
```
