### PR TITLE
Make Profiler service an optional argument for SymfonyProfilerController

### DIFF
--- a/Resources/config/symfony_profiler.yaml
+++ b/Resources/config/symfony_profiler.yaml
@@ -11,5 +11,6 @@ services:
     tags: ['container.service_subscriber']
     arguments:
       - '@Translation\Bundle\Service\StorageService'
-      - '@profiler'
       - '%php_translation.toolbar.allow_edit%'
+    calls:
+      - setProfiler: ['@?profiler']


### PR DESCRIPTION
Fixes #436

These changes allow us to keep the profiler feature enabled by default in the recipe: https://github.com/symfony/recipes-contrib/blob/ff7313b337a4c0ec894684f71b62240a31816e9f/php-translation/symfony-bundle/0.10/config/packages/dev/php_translation.yaml#L3 to have good discoverability of the feature for those who have the `symfony/web-profiler-bundle` installed but won't throw an exception if the `symfony/web-profiler-bundle ` is missing in the project on `composer require php-translation/symfony-bundle`. If somehow this feature will be tried to use - we will show a clear user-friendly message about requiring `symfony/web-profiler-bundle` dependency first.