### PR TITLE
Drop SensioLabs (Symfony) insight badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 # Translation Bundle
 
 [![Latest Version](https://img.shields.io/github/release/php-translation/symfony-bundle.svg?style=flat-square)](https://github.com/php-translation/symfony-bundle/releases)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/c289ebe2-41c4-429f-afba-de2f905b9bdb/mini.png)](https://insight.sensiolabs.com/projects/c289ebe2-41c4-429f-afba-de2f905b9bdb)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-translation/symfony-bundle.svg?style=flat-square)](https://packagist.org/packages/php-translation/symfony-bundle)
 
 **Symfony integration for PHP Translation**


### PR DESCRIPTION
First of all, the correct link should be https://insight.symfony.com/projects/c289ebe2-41c4-429f-afba-de2f905b9bdb - but there's no data, so probably better to remove the badge completely instead of showing failed badge for now