### PR TITLE
Suppress getMasterRequest() deprecation message

### DIFF
--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Bundle\Legacy;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * A legacy helper to suppress deprecations on RequestStack
+ *
+ * @author Victor Bocharsky <bocharsky.bw@gmail.com>
+ */
+class LegacyHelper
+{
+    public static function getMainRequest(RequestStack $requestStack)
+    {
+        if (method_exists($requestStack, 'getMainRequest')) {
+            return $requestStack->getMainRequest();
+        }
+
+        return $requestStack->getMasterRequest();
+    }
+}

--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -14,7 +14,7 @@ namespace Translation\Bundle\Legacy;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * A legacy helper to suppress deprecations on RequestStack
+ * A legacy helper to suppress deprecations on RequestStack.
  *
  * @author Victor Bocharsky <bocharsky.bw@gmail.com>
  */
@@ -22,7 +22,7 @@ class LegacyHelper
 {
     public static function getMainRequest(RequestStack $requestStack)
     {
-        if (method_exists($requestStack, 'getMainRequest')) {
+        if (\method_exists($requestStack, 'getMainRequest')) {
             return $requestStack->getMainRequest();
         }
 

--- a/Translator/EditInPlaceTranslator.php
+++ b/Translator/EditInPlaceTranslator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterfa
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface as NewTranslatorInterface;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
+use Translation\Bundle\Legacy\LegacyHelper;
 
 /**
  * Custom Translator for HTML rendering only (output `<x-trans>` tags).
@@ -75,7 +76,8 @@ final class EditInPlaceTranslator implements TranslatorInterface
     public function trans($id, array $parameters = [], $domain = null, $locale = null): ?string
     {
         $original = $this->translator->trans($id, $parameters, $domain, $locale);
-        if (!$this->activator->checkRequest($this->requestStack->getMasterRequest())) {
+        $request = LegacyHelper::getMainRequest($this->requestStack);
+        if (!$this->activator->checkRequest($request)) {
             return $original;
         }
 
@@ -105,7 +107,8 @@ final class EditInPlaceTranslator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): ?string
     {
-        if (!$this->activator->checkRequest($this->requestStack->getMasterRequest())) {
+        $request = LegacyHelper::getMainRequest($this->requestStack);
+        if (!$this->activator->checkRequest($request)) {
             return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
         }
 

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -14,6 +14,7 @@ namespace Translation\Bundle\Twig;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
+use Translation\Bundle\Legacy\LegacyHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -52,7 +53,9 @@ final class EditInPlaceExtension extends AbstractExtension
      */
     public function isSafe($node): array
     {
-        return $this->activator->checkRequest($this->requestStack->getMasterRequest()) ? ['html'] : [];
+        $request = LegacyHelper::getMainRequest($this->requestStack);
+
+        return $this->activator->checkRequest($request) ? ['html'] : [];
     }
 
     /**


### PR DESCRIPTION
Suppress this deprecation message:

> Since symfony/http-foundation 5.3: "Symfony\Component\HttpFoundation\RequestStack::getMasterRequest()" is deprecated, use "getMainRequest()" instead.
