### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -93,8 +93,8 @@ XML
         $output = $commandTester->getDisplay();
 
         // Make sure we have 4 new messages
-        $this->assertRegExp('|New messages +4|s', $output);
-        $this->assertRegExp('|Total defined messages +8|s', $output);
+        $this->assertMatchesRegularExpression('|New messages +4|s', $output);
+        $this->assertMatchesRegularExpression('|Total defined messages +8|s', $output);
 
         $container = $this->getContainer();
         $config = $container->get(ConfigurationManager::class)->getConfiguration('app');

--- a/Tests/Functional/Command/SyncCommandTest.php
+++ b/Tests/Functional/Command/SyncCommandTest.php
@@ -80,8 +80,8 @@ XML
 
             $this->fail('The command should fail when called with an unknown configuration key.');
         } catch (\InvalidArgumentException $e) {
-            $this->assertRegExp('|Unknown storage "fail"\.|s', $e->getMessage());
-            $this->assertRegExp('|Available storages are "app"|s', $e->getMessage());
+            $this->assertMatchesRegularExpression('|Unknown storage "fail"\.|s', $e->getMessage());
+            $this->assertMatchesRegularExpression('|Available storages are "app"|s', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
> `assertRegExp()` is deprecated and will be removed in PHPUnit 10. Refactor your code to use `assertMatchesRegularExpression()` instead.