### PR TITLE
Review deprecations

### DIFF
--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -28,7 +28,7 @@ class LegacyHelper
             return $requestStack->getMainRequest();
         }
 
-        return $requestStack->getMasterRequest();
+        return $requestStack->getMainRequest();
     }
 
     /**

--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -41,11 +41,11 @@ class LegacyHelper
             $service = $servicesConfigurator->set($id)
                 ->parent($parent);
 
-            if (Kernel::VERSION_ID < 50100) {
-                $service->deprecate('Since php-translation/symfony-bundle 0.10.0: The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.');
-            } else {
-                $service->deprecate('php-translation/symfony-bundle', '0.10.0', 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.');
-            }
+            $service->deprecate(
+                'php-translation/symfony-bundle',
+                '0.10.0',
+                'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.'
+            );
 
             if ($isPublic) {
                 $service->public();

--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -24,10 +24,6 @@ class LegacyHelper
 {
     public static function getMainRequest(RequestStack $requestStack)
     {
-        if (\method_exists($requestStack, 'getMainRequest')) {
-            return $requestStack->getMainRequest();
-        }
-
         return $requestStack->getMainRequest();
     }
 


### PR DESCRIPTION
Change getMasterRequest to getMainRequest

Change single-argument call of `deprecate()` to `symfony/dependency-injection` v5.1 standard

This can be safely done as in the project we're using this VCS repository the Symfony version suppress those. 