### PR TITLE
refac: remove AbstractController from EditInPlaceController

### DIFF
--- a/Controller/EditInPlaceController.php
+++ b/Controller/EditInPlaceController.php
@@ -11,7 +11,6 @@
 
 namespace Translation\Bundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -25,7 +24,7 @@ use Translation\Common\Model\MessageInterface;
 /**
  * @author Damien Alexandre <dalexandre@jolicode.com>
  */
-class EditInPlaceController extends AbstractController
+class EditInPlaceController
 {
     private $storageManager;
     private $cacheClearer;


### PR DESCRIPTION
Fix deprecation
```
Since symfony/dependency-injection 5.1: The "Psr\Container\ContainerInterface" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it. It is being referenced by the "Translation\Bundle\Controller\EditInPlaceController" service.
```

related also to #455