### PR TITLE
Fix Cannot autowire service "php_translation.data_collector" error in…

### DIFF
--- a/Resources/config/symfony_profiler.yaml
+++ b/Resources/config/symfony_profiler.yaml
@@ -6,6 +6,7 @@ services:
 
   php_translation.data_collector:
     class: Symfony\Component\Translation\DataCollector\TranslationDataCollector
+    arguments: [ '@translator.data_collector' ]
     tags:
       - { name: 'data_collector', template: "@Translation/SymfonyProfiler/translation.html.twig", id: "translation", priority: 200 }
 


### PR DESCRIPTION
Fix Cannot autowire service "php_translation.data_collector" error introduced in d47279e.

See https://github.com/php-translation/symfony-bundle/commit/d47279e2909bfcca8a7801e105e2da8a19b2367d#commitcomment-64500173