### PR TITLE
Migrate PHPUnit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     <php>
         <env name="ENV" value="test" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=1" />
+        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="false"
          convertErrorsToExceptions="true"
@@ -9,15 +9,12 @@
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="./vendor/autoload.php"
-        >
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
     <php>
         <env name="ENV" value="test" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=1" />
     </php>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 
     <testsuites>
         <testsuite name="Test Suite">
@@ -25,13 +22,17 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">./</directory>
-            <exclude>
-                <directory>vendor</directory>
-                <directory>Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>vendor</directory>
+            <directory>Tests</directory>
+        </exclude>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
From the CLI:
```
$ ./vendor/bin/simple-phpunit
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing
............................................................      60 / 60 (100%)
```