### PR TITLE
Drop PHP 7.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.3', '7.4', '8.0', '8.1' ]
         strategy: [ 'highest' ]
         sf_version: ['']
         include:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "symfony/framework-bundle": "^4.4.20 || ^5.2.5 || ^6.0",
         "symfony/validator": "^4.4.20 || ^5.2.5 || ^6.0",
         "symfony/translation": "^4.4.20 || ^5.2.5 || ^6.0",


### PR DESCRIPTION
First of all, because PHP 7.2 EOL was a year ago, see https://www.php.net/supported-versions.php . And second - it should help to fix tests in #466 so we could use PHPUnit 9.5 in all builds

P.S. What about 7.3 support? It's also EOL, but it happened at the end of 2021. I'm fine to keep it for a while though
