### PR TITLE
Fix for deprecated session service in Symfony 6

### DIFF
--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -40,7 +40,7 @@ final class Activator implements ActivatorInterface
     }
 
     /**
-     * Set session if available
+     * Set session if available.
      */
     public function setSession(Session $session): void
     {
@@ -48,13 +48,15 @@ final class Activator implements ActivatorInterface
     }
 
     /**
-     * Get session based on availability
+     * Get session based on availability.
      */
-    private function getSession(): Session {
+    private function getSession(): Session
+    {
         $session = $this->session;
-        if (is_null($session)) {
+        if (null === $session) {
             $session = $this->requestStack->getSession();
         }
+
         return $session;
     }
 

--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -12,7 +12,7 @@
 namespace Translation\Bundle\EditInPlace;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Default Activator implementation.
@@ -24,13 +24,13 @@ final class Activator implements ActivatorInterface
     const KEY = 'translation_bundle.edit_in_place.enabled';
 
     /**
-     * @var Session
+     * @var RequestStack
      */
-    private $session;
+    private $requestStack;
 
-    public function __construct(Session $session)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->session = $session;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -38,7 +38,7 @@ final class Activator implements ActivatorInterface
      */
     public function activate(): void
     {
-        $this->session->set(self::KEY, true);
+        $this->requestStack->getSession()->set(self::KEY, true);
     }
 
     /**
@@ -46,7 +46,7 @@ final class Activator implements ActivatorInterface
      */
     public function deactivate(): void
     {
-        $this->session->remove(self::KEY);
+        $this->requestStack->getSession()->remove(self::KEY);
     }
 
     /**
@@ -54,10 +54,10 @@ final class Activator implements ActivatorInterface
      */
     public function checkRequest(Request $request = null): bool
     {
-        if (!$this->session->has(self::KEY)) {
+        if (!$this->requestStack->getSession()->has(self::KEY)) {
             return false;
         }
 
-        return $this->session->get(self::KEY, false);
+        return $this->requestStack->getSession()->get(self::KEY, false);
     }
 }

--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -13,6 +13,7 @@ namespace Translation\Bundle\EditInPlace;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * Default Activator implementation.
@@ -28,9 +29,33 @@ final class Activator implements ActivatorInterface
      */
     private $requestStack;
 
+    /**
+     * @var Session|null
+     */
+    private $session = null;
+
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Set session if available
+     */
+    public function setSession(Session $session): void
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Get session based on availability
+     */
+    private function getSession(): Session {
+        $session = $this->session;
+        if (is_null($session)) {
+            $session = $this->requestStack->getSession();
+        }
+        return $session;
     }
 
     /**
@@ -38,7 +63,7 @@ final class Activator implements ActivatorInterface
      */
     public function activate(): void
     {
-        $this->requestStack->getSession()->set(self::KEY, true);
+        $this->getSession()->set(self::KEY, true);
     }
 
     /**
@@ -46,7 +71,7 @@ final class Activator implements ActivatorInterface
      */
     public function deactivate(): void
     {
-        $this->requestStack->getSession()->remove(self::KEY);
+        $this->getSession()->remove(self::KEY);
     }
 
     /**
@@ -54,10 +79,10 @@ final class Activator implements ActivatorInterface
      */
     public function checkRequest(Request $request = null): bool
     {
-        if (!$this->requestStack->getSession()->has(self::KEY)) {
+        if (!$this->getSession()->has(self::KEY)) {
             return false;
         }
 
-        return $this->requestStack->getSession()->get(self::KEY, false);
+        return $this->getSession()->get(self::KEY, false);
     }
 }

--- a/Resources/config/edit_in_place.yaml
+++ b/Resources/config/edit_in_place.yaml
@@ -20,6 +20,8 @@ services:
 
     Translation\Bundle\EditInPlace\Activator:
         arguments: ['@request_stack']
+        calls:
+            - setSession: ['@?session']
         public: true
 
     Translation\Bundle\Translator\EditInPlaceTranslator:

--- a/Resources/config/edit_in_place.yaml
+++ b/Resources/config/edit_in_place.yaml
@@ -19,7 +19,7 @@ services:
             - ~
 
     Translation\Bundle\EditInPlace\Activator:
-        arguments: ['@session']
+        arguments: ['@request_stack']
         public: true
 
     Translation\Bundle\Translator\EditInPlaceTranslator:


### PR DESCRIPTION
This change is necessary to fix an error created by a removed deprecation.

deprecation:
https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation