### PR TITLE
fix: used finder->exclude instead of notPath for excludedDirs

### DIFF
--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -143,7 +143,7 @@ class ExtractCommand extends Command
         $finder->in($config->getDirs());
 
         foreach ($config->getExcludedDirs() as $exclude) {
-            $finder->notPath($exclude);
+            $finder->exclude($exclude);
         }
 
         foreach ($config->getExcludedNames() as $exclude) {

--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -71,7 +71,7 @@ class SymfonyProfilerController
             return new Response($content);
         }
 
-        //Assert: This is a POST request
+        // Assert: This is a POST request
         $message->setTranslation((string) $request->request->get('translation'));
         $this->storage->update($message->convertToMessage());
 


### PR DESCRIPTION
Closes #284 excluded_dirs in config matches filenames too

tested it with my project (exclude_dir "data"). My file "base_data" is now correctly extracted, while translations inside my "data" folder are ignored as expected.

Only possible issue I see is some users expecting "exclude_dirs" to also exclude filenames, which would be a bit weird as it's been marked as bug since 3 years.
Anyway, that could be easily fixed by simply adding the values of "excluded_dirs" to "excluded_names".