### PR TITLE
fix: check if session if available

### DIFF
--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -50,10 +50,10 @@ final class Activator implements ActivatorInterface
     /**
      * Get session based on availability.
      */
-    private function getSession(): Session
+    private function getSession(): ?Session
     {
         $session = $this->session;
-        if (null === $session) {
+        if (null === $session && $this->requestStack->getCurrentRequest()->hasSession()) {
             $session = $this->requestStack->getSession();
         }
 
@@ -65,7 +65,9 @@ final class Activator implements ActivatorInterface
      */
     public function activate(): void
     {
-        $this->getSession()->set(self::KEY, true);
+        if (null !== $this->getSession()) {
+            $this->getSession()->set(self::KEY, true);
+        }
     }
 
     /**
@@ -73,7 +75,9 @@ final class Activator implements ActivatorInterface
      */
     public function deactivate(): void
     {
-        $this->getSession()->remove(self::KEY);
+        if (null !== $this->getSession()) {
+            $this->getSession()->remove(self::KEY);
+        }
     }
 
     /**
@@ -81,7 +85,7 @@ final class Activator implements ActivatorInterface
      */
     public function checkRequest(Request $request = null): bool
     {
-        if (!$this->getSession()->has(self::KEY)) {
+        if (null === $this->getSession() || !$this->getSession()->has(self::KEY)) {
             return false;
         }
 


### PR DESCRIPTION
In some requests no session is available.
I have this problem specifically when using cross domain requests in the preflight request. 
This gives an error in the activator for 'edit in place'. Checking if the session is available before executing the code solves the problem.