### PR TITLE
Upgrade the SymfonyBundleTest

### DIFF
--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -53,7 +53,8 @@ final class Activator implements ActivatorInterface
     private function getSession(): ?Session
     {
         $session = $this->session;
-        if (null === $session && $this->requestStack->getCurrentRequest()->hasSession()) {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $session && $request && $request->hasSession()) {
             $session = $this->requestStack->getSession();
         }
 

--- a/Model/SfProfilerMessage.php
+++ b/Model/SfProfilerMessage.php
@@ -80,9 +80,6 @@ final class SfProfilerMessage
      */
     private $parameters;
 
-    /**
-     * @return SfProfilerMessage
-     */
     public static function create(array $data): self
     {
         $message = new self();

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -15,6 +15,7 @@ use Nyholm\BundleTest\TestKernel;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\HttpKernel\Kernel;
 use Translation\Bundle\TranslationBundle;
 
 /**
@@ -36,7 +37,11 @@ abstract class BaseTestCase extends KernelTestCase
     {
         $kernel = self::createKernel();
 
-        $kernel->addTestConfig(__DIR__.'/app/config/default.yaml');
+        if (Kernel::VERSION_ID < 50300) {
+            $kernel->addTestConfig(__DIR__.'/app/config/default_legacy.yaml');
+        } else {
+            $kernel->addTestConfig(__DIR__.'/app/config/default.yaml');
+        }
 
         $kernel->addTestBundle(TwigBundle::class);
         $kernel->addTestBundle(TranslationBundle::class);

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -12,8 +12,8 @@
 namespace Translation\Bundle\Tests\Functional;
 
 use Nyholm\BundleTest\TestKernel;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Translation\Bundle\TranslationBundle;
 

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -11,8 +11,8 @@
 
 namespace Translation\Bundle\Tests\Functional;
 
-use Nyholm\BundleTest\AppKernel;
-use Nyholm\BundleTest\BaseBundleTestCase;
+use Nyholm\BundleTest\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Translation\Bundle\TranslationBundle;
@@ -20,12 +20,12 @@ use Translation\Bundle\TranslationBundle;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class BaseTestCase extends BaseBundleTestCase
+abstract class BaseTestCase extends KernelTestCase
 {
     /**
-     * @var AppKernel
+     * @var TestKernel
      */
-    protected $kernel;
+    protected $testKernel;
 
     protected function getBundleClass(): string
     {
@@ -34,13 +34,14 @@ abstract class BaseTestCase extends BaseBundleTestCase
 
     protected function setUp(): void
     {
-        $kernel = $this->createKernel();
-        $kernel->addConfigFile(__DIR__.'/app/config/default.yaml');
+        $kernel = self::createKernel();
 
-        $kernel->addBundle(TwigBundle::class);
-        $kernel->addBundle(TranslationBundle::class);
+        $kernel->addTestConfig(__DIR__.'/app/config/default.yaml');
 
-        $this->kernel = $kernel;
+        $kernel->addTestBundle(TwigBundle::class);
+        $kernel->addTestBundle(TranslationBundle::class);
+
+        $this->testKernel = $kernel;
 
         parent::setUp();
     }

--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -21,8 +21,10 @@ class BundleInitializationTest extends BaseTestCase
 {
     public function testRegisterBundle(): void
     {
-        $this->bootKernel();
-        $container = $this->getContainer();
+        $kernel = $this->testKernel;
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
         $this->assertTrue($container->has(ConfigurationManager::class));
         $config = $container->get(ConfigurationManager::class);
         $this->assertInstanceOf(ConfigurationManager::class, $config);

--- a/Tests/Functional/Catalogue/CatalogueFetcherTest.php
+++ b/Tests/Functional/Catalogue/CatalogueFetcherTest.php
@@ -52,9 +52,8 @@ XML
 
     public function testFetchCatalogue(): void
     {
-        $this->bootKernel();
-
-        $this->catalogueFetcher = $this->getContainer()->get(CatalogueFetcher::class);
+        $this->testKernel->boot();
+        $this->catalogueFetcher = $this->testKernel->getContainer()->get(CatalogueFetcher::class);
 
         $data = self::getDefaultData();
         $data['external_translations_dirs'] = [__DIR__.'/../app/Resources/translations/'];
@@ -89,6 +88,6 @@ XML
     {
         parent::setUp();
 
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
     }
 }

--- a/Tests/Functional/Command/CheckMissingCommandTest.php
+++ b/Tests/Functional/Command/CheckMissingCommandTest.php
@@ -19,9 +19,9 @@ class CheckMissingCommandTest extends BaseTestCase
     {
         parent::setUp();
 
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
-        $this->bootKernel();
-        $this->application = new Application($this->kernel);
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
+        $this->testKernel->boot();
+        $this->application = new Application($this->testKernel);
 
         file_put_contents(
             __DIR__.'/../app/Resources/translations/messages.sv.xlf',

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -25,7 +25,8 @@ class ExtractCommandTest extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
 
         file_put_contents(__DIR__.'/../app/Resources/translations/messages.sv.xlf', <<<'XML'
 <?xml version="1.0" encoding="utf-8"?>
@@ -67,10 +68,10 @@ XML
 
     public function testExecute(): void
     {
-        $this->bootKernel();
-        $application = new Application($this->kernel);
+        $this->testKernel->boot();
+        $application = new Application($this->testKernel);
 
-        $container = $this->getContainer();
+        $container = $this->testKernel->getContainer();
         $application->add($container->get(ExtractCommand::class));
 
         // transchoice tag have been definively removed in sf ^5.0
@@ -96,7 +97,6 @@ XML
         $this->assertMatchesRegularExpression('|New messages +4|s', $output);
         $this->assertMatchesRegularExpression('|Total defined messages +8|s', $output);
 
-        $container = $this->getContainer();
         $config = $container->get(ConfigurationManager::class)->getConfiguration('app');
         $catalogues = $container->get(CatalogueFetcher::class)->getCatalogues($config, ['sv']);
 

--- a/Tests/Functional/Command/StatusCommandTest.php
+++ b/Tests/Functional/Command/StatusCommandTest.php
@@ -21,15 +21,16 @@ class StatusCommandTest extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
     }
 
     public function testExecute(): void
     {
-        $this->bootKernel();
-        $application = new Application($this->kernel);
+        $this->testKernel->boot();
+        $application = new Application($this->testKernel);
 
-        $container = $this->getContainer();
+        $container = $this->testKernel->getContainer();
         $application->add($container->get(StatusCommand::class));
 
         $command = $application->find('translation:status');

--- a/Tests/Functional/Command/SyncCommandTest.php
+++ b/Tests/Functional/Command/SyncCommandTest.php
@@ -21,7 +21,8 @@ class SyncCommandTest extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
 
         file_put_contents(__DIR__.'/../app/Resources/translations/messages.sv.xlf', <<<'XML'
 <?xml version="1.0" encoding="utf-8"?>
@@ -63,10 +64,10 @@ XML
 
     public function testExecute(): void
     {
-        $this->bootKernel();
-        $application = new Application($this->kernel);
+        $this->testKernel->boot();
+        $application = new Application($this->testKernel);
 
-        $container = $this->getContainer();
+        $container = $this->testKernel->getContainer();
         $application->add($container->get(SyncCommand::class));
 
         $command = $application->find('translation:sync');

--- a/Tests/Functional/Controller/EditInPlaceControllerTest.php
+++ b/Tests/Functional/Controller/EditInPlaceControllerTest.php
@@ -49,7 +49,8 @@ XML
     protected function setUp(): void
     {
         parent::setUp();
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
     }
 
     public function testEditAction(): void
@@ -58,7 +59,7 @@ XML
             'messages|key0' => 'trans0',
             'messages|key1' => 'trans1',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -68,7 +69,7 @@ XML
             'messages|key0' => 'trans0',
             'messages|' => 'trans1',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(400, $response->getStatusCode());
     }
 }

--- a/Tests/Functional/Controller/EditInPlaceTest.php
+++ b/Tests/Functional/Controller/EditInPlaceTest.php
@@ -22,13 +22,13 @@ class EditInPlaceTest extends BaseTestCase
 {
     public function testActivatedTest(): void
     {
-        $this->bootKernel();
+        $this->testKernel->boot();
         $request = Request::create('/foobar');
 
         // Activate the feature
-        $this->getContainer()->get(Activator::class)->activate();
+        $this->testKernel->getContainer()->get(Activator::class)->activate();
 
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('<!-- TranslationBundle -->', $response->getContent());
@@ -53,14 +53,14 @@ class EditInPlaceTest extends BaseTestCase
 
     public function testIfUntranslatableLabelGetsDisabled(): void
     {
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/disabled_label.yaml');
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/disabled_label.yaml');
         $request = Request::create('/foobar');
 
         // Activate the feature
-        $this->bootKernel();
-        $this->getContainer()->get(Activator::class)->activate();
+        $this->testKernel->boot();
+        $this->testKernel->getContainer()->get(Activator::class)->activate();
 
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('<!-- TranslationBundle -->', $response->getContent());
@@ -85,9 +85,10 @@ class EditInPlaceTest extends BaseTestCase
 
     public function testDeactivatedTest(): void
     {
-        $this->bootKernel();
+        $this->testKernel->boot();
+
         $request = Request::create('/foobar');
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringNotContainsString('x-trans', $response->getContent());

--- a/Tests/Functional/Controller/EditInPlaceTest.php
+++ b/Tests/Functional/Controller/EditInPlaceTest.php
@@ -14,6 +14,7 @@ namespace Translation\Bundle\Tests\Functional\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Kernel;
 use Translation\Bundle\EditInPlace\Activator;
 use Translation\Bundle\Tests\Functional\BaseTestCase;
 
@@ -58,7 +59,11 @@ class EditInPlaceTest extends BaseTestCase
 
     public function testIfUntranslatableLabelGetsDisabled(): void
     {
-        $this->testKernel->addTestConfig(__DIR__.'/../app/config/disabled_label.yaml');
+        if (Kernel::VERSION_ID < 50300) {
+            $this->testKernel->addTestConfig(__DIR__.'/../app/config/disabled_label_legacy.yaml');
+        } else {
+            $this->testKernel->addTestConfig(__DIR__.'/../app/config/disabled_label.yaml');
+        }
         $this->testKernel->boot();
         $request = Request::create('/foobar');
 

--- a/Tests/Functional/Controller/EditInPlaceTest.php
+++ b/Tests/Functional/Controller/EditInPlaceTest.php
@@ -12,6 +12,8 @@
 namespace Translation\Bundle\Tests\Functional\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Translation\Bundle\EditInPlace\Activator;
 use Translation\Bundle\Tests\Functional\BaseTestCase;
 
@@ -26,7 +28,10 @@ class EditInPlaceTest extends BaseTestCase
         $request = Request::create('/foobar');
 
         // Activate the feature
-        $this->testKernel->getContainer()->get(Activator::class)->activate();
+        $activator = $this->testKernel->getContainer()->get(Activator::class);
+        $session = new Session(new MockArraySessionStorage());
+        $activator->setSession($session);
+        $activator->activate();
 
         $response = $this->testKernel->handle($request);
 
@@ -54,11 +59,14 @@ class EditInPlaceTest extends BaseTestCase
     public function testIfUntranslatableLabelGetsDisabled(): void
     {
         $this->testKernel->addTestConfig(__DIR__.'/../app/config/disabled_label.yaml');
+        $this->testKernel->boot();
         $request = Request::create('/foobar');
 
         // Activate the feature
-        $this->testKernel->boot();
-        $this->testKernel->getContainer()->get(Activator::class)->activate();
+        $activator = $this->testKernel->getContainer()->get(Activator::class);
+        $session = new Session(new MockArraySessionStorage());
+        $activator->setSession($session);
+        $activator->activate();
 
         $response = $this->testKernel->handle($request);
 

--- a/Tests/Functional/Controller/WebUIControllerTest.php
+++ b/Tests/Functional/Controller/WebUIControllerTest.php
@@ -46,24 +46,25 @@ XML
     protected function setUp(): void
     {
         parent::setUp();
-        $this->kernel->addConfigFile(__DIR__.'/../app/config/normal_config.yaml');
+
+        $this->testKernel->addTestConfig(__DIR__.'/../app/config/normal_config.yaml');
     }
 
     public function testIndexAction(): void
     {
         $request = Request::create('/_trans', 'GET');
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
 
         $request = Request::create('/_trans/app', 'GET');
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testShowAction(): void
     {
         $request = Request::create('/_trans/app/en/messages', 'GET');
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -72,14 +73,14 @@ XML
         $request = Request::create('/_trans/app/sv/messages/new', 'POST', [], [], [], [], json_encode([
             'key' => 'foo',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(400, $response->getStatusCode());
 
         $request = Request::create('/_trans/app/sv/messages/new', 'POST', [], [], [], [], json_encode([
             'key' => 'foo',
             'message' => 'bar',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -88,14 +89,14 @@ XML
         $request = Request::create('/_trans/app/sv/messages', 'POST', [], [], [], [], json_encode([
             'key' => 'foo',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(400, $response->getStatusCode());
 
         $request = Request::create('/_trans/app/sv/messages', 'POST', [], [], [], [], json_encode([
             'key' => 'key1',
             'message' => 'bar',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -105,13 +106,13 @@ XML
         $request = Request::create('/_trans/app/sv/messages', 'DELETE', [], [], [], [], json_encode([
             'key' => 'empty',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
 
         $request = Request::create('/_trans/app/sv/messages', 'DELETE', [], [], [], [], json_encode([
             'key' => 'foo',
         ]));
-        $response = $this->kernel->handle($request);
+        $response = $this->testKernel->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/Tests/Functional/app/Service/DummyHttpClient.php
+++ b/Tests/Functional/app/Service/DummyHttpClient.php
@@ -11,14 +11,16 @@
 
 namespace Translation\Bundle\Tests\Functional\app\Service;
 
-use GuzzleHttp\Psr7\Response;
 use Http\Client\HttpClient;
+use Nyholm\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class DummyHttpClient implements HttpClient
 {
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
+
         return new Response(200);
     }
 }

--- a/Tests/Functional/app/Service/DummyHttpClient.php
+++ b/Tests/Functional/app/Service/DummyHttpClient.php
@@ -20,7 +20,6 @@ class DummyHttpClient implements HttpClient
 {
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
-
         return new Response(200);
     }
 }

--- a/Tests/Functional/app/Service/DummyMessageFactory.php
+++ b/Tests/Functional/app/Service/DummyMessageFactory.php
@@ -11,9 +11,9 @@
 
 namespace Translation\Bundle\Tests\Functional\app\Service;
 
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use Http\Message\MessageFactory;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
 
 class DummyMessageFactory implements MessageFactory
 {

--- a/Tests/Functional/app/config/default_legacy.yaml
+++ b/Tests/Functional/app/config/default_legacy.yaml
@@ -1,0 +1,10 @@
+imports:
+    - { resource: parameters.php }
+    - { resource: framework_legacy.yaml }
+    - { resource: services.yaml }
+
+translation:
+  webui:
+    enabled: true
+  edit_in_place:
+    enabled: true

--- a/Tests/Functional/app/config/disabled_label_legacy.yaml
+++ b/Tests/Functional/app/config/disabled_label_legacy.yaml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: default_legacy.yaml }
+
+translation:
+  edit_in_place:
+    show_untranslatable: false

--- a/Tests/Functional/app/config/framework.yaml
+++ b/Tests/Functional/app/config/framework.yaml
@@ -2,7 +2,7 @@ framework:
     secret: test
     test: ~
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     form: false
     csrf_protection: false
     validation:

--- a/Tests/Functional/app/config/framework_legacy.yaml
+++ b/Tests/Functional/app/config/framework_legacy.yaml
@@ -1,0 +1,17 @@
+framework:
+    secret: test
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    form: false
+    csrf_protection: false
+    validation:
+        enabled: true
+    router:
+        resource: "%test.project_dir%/config/routing.yaml"
+        type: 'yaml'
+
+twig:
+  strict_variables: "%kernel.debug%" #suppresses deprecation notices about the default value TwigBundle pre version 5
+  paths:
+    "%test.project_dir%/Resources/views": App

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "matthiasnoback/symfony-config-test": "^4.1",
         "nyholm/psr7": "^1.1",
-        "nyholm/symfony-bundle-test": "^1.6.1, <1.8"
+        "nyholm/symfony-bundle-test": "^2.0"
     },
     "suggest": {
         "php-http/httplug-bundle": "To easier configure your httplug clients."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
     <php>
         <env name="ENV" value="test" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=1" />
+        <env name="KERNEL_CLASS" value="Nyholm\BundleTest\TestKernel" />
     </php>
 
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         >
     <php>
         <env name="ENV" value="test" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=29&amp;verbose=1" />
         <env name="KERNEL_CLASS" value="Nyholm\BundleTest\TestKernel" />
     </php>
 


### PR DESCRIPTION
The `nyholm/symfony-bundle-test` prevents to upgrade to Symfony 6 completely as `symfony/framework-bundle` because it's installed as 5.4 for the current version SymfonyBundleTest version, see installed deps here: https://github.com/php-translation/symfony-bundle/runs/8168054961?check_suite_focus=true

I tried to upgrade it to the v2.0 and fixed broken tests so that this bundle could use all Symfony 6 packages finally.
