### PR TITLE
Symfony Profiler Fix Symfony 6.x compatibility

### DIFF
--- a/Controller/SymfonyProfilerController.php
+++ b/Controller/SymfonyProfilerController.php
@@ -166,8 +166,12 @@ class SymfonyProfilerController
     {
         $this->getProfiler()->disable();
 
+        $parameters = $request->request->all();
+        if (!isset($parameters['selected'])) {
+            return [];
+        }
         /** @var string[] $selected */
-        $selected = (array) $request->request->get('selected');
+        $selected = (array) $parameters['selected'];
         if (0 === \count($selected)) {
             return [];
         }


### PR DESCRIPTION
Symfony 6.x dropped support for request->get returning arrays. I am not using request->all($key) construction to maintain Symfony 4.4 compatibility.