### PR TITLE
Remove symfony console $defaultName deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: ['8.0', '8.1' '8.2']
         strategy: [ 'highest' ]
         sf_version: ['']
         include:
-            - php: 7.4
+            - php: 8.0
               strategy: 'lowest'
-            - php: 7.3
-              sf_version: '4.*'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1' '8.2']
+        php: ['8.0', '8.1', '8.2']
         strategy: [ 'highest' ]
         sf_version: ['']
         include:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           coverage: none
 
       - name: Download dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           coverage: none
 
       - name: Download dependencies

--- a/Catalogue/CatalogueManager.php
+++ b/Catalogue/CatalogueManager.php
@@ -67,12 +67,12 @@ final class CatalogueManager
     /**
      * @param array $config {
      *
-     *      @var string $domain
-     *      @var string $locale
-     *      @var bool $isNew
-     *      @var bool $isObsolete
-     *      @var bool $isApproved
-     * }
+     * @var string $domain
+     * @var string $locale
+     * @var bool   $isNew
+     * @var bool   $isObsolete
+     * @var bool   $isApproved
+     *             }
      *
      * @return CatalogueMessage[]
      */

--- a/Catalogue/Operation/ReplaceOperation.php
+++ b/Catalogue/Operation/ReplaceOperation.php
@@ -150,12 +150,12 @@ final class ReplaceOperation extends AbstractOperation
                         // If both arrays, do recursive call
                         $source[$key] = $this->doMergeMetadata($source[$key], $value);
                     }
-                // Else, use value form $source
+                    // Else, use value form $source
                 } else {
                     // Add new value
                     $source[$key] = $value;
                 }
-            // if sequential
+                // if sequential
             } elseif (!\in_array($value, $source, true)) {
                 $source[] = $value;
             }

--- a/Command/BundleTrait.php
+++ b/Command/BundleTrait.php
@@ -20,7 +20,7 @@ trait BundleTrait
     private function configureBundleDirs(InputInterface $input, Configuration $config): void
     {
         if ($bundleName = $input->getOption('bundle')) {
-            if (0 === strpos($bundleName, '@')) {
+            if (str_starts_with($bundleName, '@')) {
                 if (false === $pos = strpos($bundleName, '/')) {
                     $bundleName = substr($bundleName, 1);
                 } else {

--- a/Command/CheckMissingCommand.php
+++ b/Command/CheckMissingCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,10 +18,11 @@ use Translation\Bundle\Model\Configuration;
 use Translation\Bundle\Service\ConfigurationManager;
 use Translation\Bundle\Service\Importer;
 
+#[AsCommand(
+    name: 'translation:check-missing'
+)]
 final class CheckMissingCommand extends Command
 {
-    protected static $defaultName = 'translation:check-missing';
-
     /**
      * @var ConfigurationManager
      */
@@ -58,7 +60,6 @@ final class CheckMissingCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Check that all translations for a given locale are extracted.')
             ->addArgument('locale', InputArgument::REQUIRED, 'The locale to check')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default');

--- a/Command/DeleteEmptyCommand.php
+++ b/Command/DeleteEmptyCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -26,12 +27,13 @@ use Translation\Bundle\Service\StorageManager;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:delete-empty'
+)]
 class DeleteEmptyCommand extends Command
 {
     use BundleTrait;
     use StorageTrait;
-
-    protected static $defaultName = 'translation:delete-empty';
 
     /**
      * @var ConfigurationManager
@@ -64,7 +66,6 @@ class DeleteEmptyCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Delete all translations currently empty.')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to use. If omitted, we use all configured locales.', null)

--- a/Command/DeleteObsoleteCommand.php
+++ b/Command/DeleteObsoleteCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -26,12 +27,13 @@ use Translation\Bundle\Service\StorageManager;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:delete-obsolete'
+)]
 class DeleteObsoleteCommand extends Command
 {
     use BundleTrait;
     use StorageTrait;
-
-    protected static $defaultName = 'translation:delete-obsolete';
 
     /**
      * @var ConfigurationManager
@@ -64,7 +66,6 @@ class DeleteObsoleteCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Delete all translations marked as obsolete.')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to use. If omitted, we use all configured locales.', null)

--- a/Command/DownloadCommand.php
+++ b/Command/DownloadCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,12 +27,13 @@ use Translation\Bundle\Service\StorageManager;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:download'
+)]
 class DownloadCommand extends Command
 {
     use BundleTrait;
     use StorageTrait;
-
-    protected static $defaultName = 'translation:download';
 
     private $configurationManager;
     private $cacheCleaner;
@@ -54,7 +56,6 @@ class DownloadCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Replace local messages with messages from remote')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> will erase all your local translations and replace them with translations downloaded from the remote.
@@ -138,7 +139,7 @@ EOT
 
         foreach ($raw as $string) {
             // Assert $string looks like "foo:bar"
-            list($key, $value) = explode(':', $string, 2);
+            [$key, $value] = explode(':', $string, 2);
             $config[$key][] = $value;
         }
 

--- a/Command/ExtractCommand.php
+++ b/Command/ExtractCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,11 +30,12 @@ use Translation\Extractor\Model\Error;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:extract'
+)]
 class ExtractCommand extends Command
 {
     use BundleTrait;
-
-    protected static $defaultName = 'translation:extract';
 
     /**
      * @var CatalogueFetcher
@@ -79,7 +81,6 @@ class ExtractCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Extract translations from source code.')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to use. If omitted, we use all configured locales.', false)

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,11 +25,12 @@ use Translation\Bundle\Service\ConfigurationManager;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:status'
+)]
 class StatusCommand extends Command
 {
     use BundleTrait;
-
-    protected static $defaultName = 'translation:status';
 
     /**
      * @var CatalogueCounter
@@ -60,7 +62,6 @@ class StatusCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Show status about your translations.')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to use. If omitted, we use all configured locales.', false)

--- a/Command/SyncCommand.php
+++ b/Command/SyncCommand.php
@@ -11,6 +11,7 @@
 
 namespace Translation\Bundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,11 +23,12 @@ use Translation\Bundle\Service\StorageService;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand(
+    name: 'translation:sync'
+)]
 class SyncCommand extends Command
 {
     use StorageTrait;
-
-    protected static $defaultName = 'translation:sync';
 
     public function __construct(StorageManager $storageManager)
     {
@@ -38,7 +40,6 @@ class SyncCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Sync the translations with the remote storage')
             ->addArgument('configuration', InputArgument::OPTIONAL, 'The configuration to use', 'default')
             ->addArgument('direction', InputArgument::OPTIONAL, 'Use "down" if local changes should be overwritten, otherwise "up"', 'down')
@@ -78,7 +79,7 @@ class SyncCommand extends Command
 
         foreach ($raw as $string) {
             // Assert $string looks like "foo:bar"
-            list($key, $value) = explode(':', $string, 2);
+            [$key, $value] = explode(':', $string, 2);
             $config[$key][] = $value;
         }
 

--- a/Controller/WebUIController.php
+++ b/Controller/WebUIController.php
@@ -76,7 +76,7 @@ class WebUIController
     /**
      * Show a dashboard for the configuration.
      */
-    public function indexAction(?string $configName = null): Response
+    public function indexAction(string $configName = null): Response
     {
         if (!$this->isWebUIEnabled) {
             return new Response('You are not allowed here. Check your config.', Response::HTTP_BAD_REQUEST);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,9 +29,6 @@ class Configuration implements ConfigurationInterface
         $this->container = $container;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('translation');

--- a/DependencyInjection/TranslationExtension.php
+++ b/DependencyInjection/TranslationExtension.php
@@ -37,9 +37,6 @@ use Translation\Extractor\Visitor\Php\Symfony\FormTypeChoices;
  */
 class TranslationExtension extends Extension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $container->setParameter('extractor_vendor_dir', $this->getExtractorVendorDirectory());
@@ -224,17 +221,11 @@ class TranslationExtension extends Extension
         $container->setParameter('php_translation.translator_service.api_key', $config['fallback_translation']['api_key']);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAlias(): string
     {
         return 'translation';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container);

--- a/EditInPlace/Activator.php
+++ b/EditInPlace/Activator.php
@@ -32,7 +32,7 @@ final class Activator implements ActivatorInterface
     /**
      * @var Session|null
      */
-    private $session = null;
+    private $session;
 
     public function __construct(RequestStack $requestStack)
     {
@@ -81,9 +81,6 @@ final class Activator implements ActivatorInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function checkRequest(Request $request = null): bool
     {
         if (null === $this->getSession() || !$this->getSession()->has(self::KEY)) {

--- a/Service/CacheClearer.php
+++ b/Service/CacheClearer.php
@@ -58,7 +58,7 @@ final class CacheClearer
      *
      * @param string|null $locale optional filter to clear only one locale
      */
-    public function clearAndWarmUp(?string $locale = null): void
+    public function clearAndWarmUp(string $locale = null): void
     {
         $translationDir = sprintf('%s/translations', $this->kernelCacheDir);
 

--- a/Service/Importer.php
+++ b/Service/Importer.php
@@ -62,10 +62,10 @@ final class Importer
      * @param MessageCatalogue[] $catalogues
      * @param array              $config     {
      *
-     *     @var array $blacklist_domains Blacklist the domains we should exclude. Cannot be used with whitelist.
-     *     @var array $whitelist_domains Whitelist the domains we should include. Cannot be used with blacklist.
-     *     @var string $project_root The project root will be removed from the source location.
-     * }
+     * @var array  $blacklist_domains Blacklist the domains we should exclude. Cannot be used with whitelist.
+     * @var array  $whitelist_domains Whitelist the domains we should include. Cannot be used with blacklist.
+     * @var string $project_root The project root will be removed from the source location.
+     *             }
      */
     public function extractToCatalogues(Finder $finder, array $catalogues, array $config = []): ImportResult
     {

--- a/Translator/FallbackTranslator.php
+++ b/Translator/FallbackTranslator.php
@@ -61,9 +61,6 @@ final class FallbackTranslator implements TranslatorInterface
         $this->defaultLocale = $defaultLocale;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         $id = (string) $id;
@@ -87,9 +84,6 @@ final class FallbackTranslator implements TranslatorInterface
         return $this->translateWithSubstitutedParameters($orgString, $locale, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): string
     {
         $id = (string) $id;
@@ -113,25 +107,16 @@ final class FallbackTranslator implements TranslatorInterface
         return $this->translateWithSubstitutedParameters($orgString, $locale, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setLocale($locale): void
     {
         $this->symfonyTranslator->setLocale($locale);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getLocale(): string
     {
         return $this->symfonyTranslator->getLocale();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCatalogue($locale = null): MessageCatalogueInterface
     {
         return $this->symfonyTranslator->getCatalogue($locale);

--- a/Twig/EditInPlaceExtension.php
+++ b/Twig/EditInPlaceExtension.php
@@ -37,9 +37,6 @@ final class EditInPlaceExtension extends AbstractExtension
         $this->activator = $activator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilters(): array
     {
         return [
@@ -58,9 +55,6 @@ final class EditInPlaceExtension extends AbstractExtension
         return $this->activator->checkRequest($request) ? ['html'] : [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return self::class;

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -71,7 +71,7 @@ final class TranslationExtension extends AbstractExtension
         return $visitors;
     }
 
-    public function transchoiceWithDefault(string $message, string $defaultMessage, int $count, array $arguments = [], ?string $domain = null, ?string $locale = null): string
+    public function transchoiceWithDefault(string $message, string $defaultMessage, int $count, array $arguments = [], string $domain = null, string $locale = null): string
     {
         if (null === $domain) {
             $domain = 'messages';
@@ -84,21 +84,11 @@ final class TranslationExtension extends AbstractExtension
         return $this->translator->transChoice($message, $count, array_merge(['%count%' => $count], $arguments), $domain, $locale);
     }
 
-    /**
-     * @param mixed $v
-     *
-     * @return mixed
-     */
     public function desc($v)
     {
         return $v;
     }
 
-    /**
-     * @param mixed $v
-     *
-     * @return mixed
-     */
     public function meaning($v)
     {
         return $v;

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,20 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "symfony/framework-bundle": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/validator": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/translation": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/twig-bundle": "^4.4.20 || ^5.2.4 || ^6.0",
-        "symfony/finder": "^4.4.20 || ^5.2.4 || ^6.0",
-        "symfony/intl": "^4.4.20 || ^5.2.4 || ^6.0",
+        "php": "^8.0",
+        "symfony/framework-bundle": "^5.3 || ^6.0",
+        "symfony/validator": "^5.3 || ^6.0",
+        "symfony/translation": "^5.3 || ^6.0",
+        "symfony/twig-bundle": "^5.3 || ^6.0",
+        "symfony/finder": "^5.3 || ^6.0",
+        "symfony/intl": "^5.3 || ^6.0",
+        "symfony/console": "^5.3 || ^6.0",
 
         "php-translation/symfony-storage": "^2.1",
         "php-translation/extractor": "^2.0",
         "nyholm/nsa": "^1.1",
         "twig/twig": "^2.14.4 || ^3.3",
-        "symfony/asset": "^4.4.20 || ^5.2.4 || ^6.0"
+        "symfony/asset": "^5.3 || ^6.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.2 || ^6.0",
@@ -31,10 +32,9 @@
         "php-http/curl-client": "^1.7 || ^2.0",
         "php-http/message": "^1.11",
         "php-http/message-factory": "^1.0.2",
-        "symfony/console": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/twig-bridge": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/dependency-injection": "^4.4.20 || ^5.2.5 || ^6.0",
-        "symfony/web-profiler-bundle": "^4.4.20 || ^5.2.4 || ^6.0",
+        "symfony/twig-bridge": "^5.3 || ^6.0",
+        "symfony/dependency-injection": "^5.3 || ^6.0",
+        "symfony/web-profiler-bundle": "^5.3 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "matthiasnoback/symfony-config-test": "^4.1",
         "nyholm/psr7": "^1.1",


### PR DESCRIPTION
- Remove symfony console $defaultName deprecation and use AsCommand annotation
- Upgrade to PHP ^8.0
- Upgrade to symfony ^5.3
Fix #490 