### PR TITLE
bug: js error use own object extends HTMLElement

### DIFF
--- a/EventListener/AutoAddMissingTranslations.php
+++ b/EventListener/AutoAddMissingTranslations.php
@@ -11,7 +11,6 @@
 
 namespace Translation\Bundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\Translation\DataCollectorTranslator;
 use Translation\Bundle\Service\StorageService;
@@ -52,11 +51,4 @@ final class AutoAddMissingTranslations
             }
         }
     }
-}
-
-// PostResponseEvent have been renamed into ResponseEvent in sf 4.3
-// @see https://github.com/symfony/symfony/blob/master/UPGRADE-4.3.md#httpkernel
-// To be removed once sf ^4.3 become the minimum supported version.
-if (!class_exists(TerminateEvent::class) && class_exists(PostResponseEvent::class)) {
-    class_alias(PostResponseEvent::class, TerminateEvent::class);
 }

--- a/EventListener/AutoAddMissingTranslations.php
+++ b/EventListener/AutoAddMissingTranslations.php
@@ -32,9 +32,6 @@ final class AutoAddMissingTranslations
      */
     private $storage;
 
-    /**
-     * @param DataCollectorTranslator $translator
-     */
     public function __construct(StorageService $storage, DataCollectorTranslator $translator = null)
     {
         $this->dataCollector = $translator;

--- a/EventListener/EditInPlaceResponseListener.php
+++ b/EventListener/EditInPlaceResponseListener.php
@@ -12,7 +12,6 @@
 namespace Translation\Bundle\EventListener;
 
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Translation\Bundle\EditInPlace\ActivatorInterface;
@@ -127,11 +126,4 @@ HTML;
 
         $event->getResponse()->setContent($content);
     }
-}
-
-// FilterResponseEvent have been renamed into ResponseEvent in sf 4.3
-// @see https://github.com/symfony/symfony/blob/master/UPGRADE-4.3.md#httpkernel
-// To be removed once sf ^4.3 become the minimum supported version.
-if (!class_exists(ResponseEvent::class) && class_exists(FilterResponseEvent::class)) {
-    class_alias(FilterResponseEvent::class, ResponseEvent::class);
 }

--- a/Resources/public/js/editInPlace.js
+++ b/Resources/public/js/editInPlace.js
@@ -8,7 +8,10 @@
  */
 (function () {
     if (typeof customElements.define !== "undefined") {
-        customElements.define("x-trans", HTMLElement);
+        // it is not possible to use HTMLElement directly
+        class XTrans extends HTMLElement {}
+
+        customElements.define("x-trans", XTrans);
 
         return;
     }


### PR DESCRIPTION
It seams that it is not allowed to use `HTMLElement` directly as constructor.

fix #409 

* remove old symfony 4 compatiblity layer (lib has min. 5.3 see composer.json)
* fix cs