### PR TITLE
Update twig deprecated call by it's updated version

### DIFF
--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -36,7 +36,7 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
     protected function doEnterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
-            $name = $node->getNode('filter')->getAttribute('value');
+            $name = $node->getAttribute('twig_callable')->getName()
 
             if ('desc' === $name || 'meaning' === $name) {
                 return $this->enterNode($node->getNode('node'), $env);


### PR DESCRIPTION
Version 3.12 of Twig deprecated the use of getNode('filter')

see https://twig.symfony.com/doc/3.x/deprecated.html#nodes