### PR TITLE
refac: replace AbstractNodeVisitor with NodeVisitorInterface

### DIFF
--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -21,7 +21,7 @@ use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Expression\Ternary\ConditionalTernary;
 use Twig\Node\Node;
 use Twig\Node\Nodes;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TwigFilter;
 
 /**
@@ -32,19 +32,16 @@ use Twig\TwigFilter;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
+final class DefaultApplyingNodeVisitor implements NodeVisitorInterface
 {
-    /**
-     * @var bool
-     */
-    private $enabled = true;
+    private bool $enabled = true;
 
     public function setEnabled(bool $bool): void
     {
         $this->enabled = $bool;
     }
 
-    public function doEnterNode(Node $node, Environment $env): Node
+    public function enterNode(Node $node, Environment $env): Node
     {
         if (!$this->enabled) {
             return $node;
@@ -141,7 +138,7 @@ final class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    public function doLeaveNode(Node $node, Environment $env): Node
+    public function leaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }

--- a/Twig/Visitor/NormalizingNodeVisitor.php
+++ b/Twig/Visitor/NormalizingNodeVisitor.php
@@ -15,7 +15,7 @@ use Twig\Environment;
 use Twig\Node\Expression\Binary\ConcatBinary;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Node;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
  * Performs equivalence transformations on the AST to ensure that
@@ -25,17 +25,14 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class NormalizingNodeVisitor extends AbstractNodeVisitor
+final class NormalizingNodeVisitor implements NodeVisitorInterface
 {
-    protected function doEnterNode(Node $node, Environment $env): Node
+    public function enterNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return ConstantExpression|Node
-     */
-    protected function doLeaveNode(Node $node, Environment $env): Node
+    public function leaveNode(Node $node, Environment $env): ConstantExpression|Node
     {
         if ($node instanceof ConcatBinary
             && ($left = $node->getNode('left')) instanceof ConstantExpression

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -14,26 +14,23 @@ namespace Translation\Bundle\Twig\Visitor;
 use Twig\Environment;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
  * Removes translation metadata filters from the AST.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-final class RemovingNodeVisitor extends AbstractNodeVisitor
+final class RemovingNodeVisitor implements NodeVisitorInterface
 {
-    /**
-     * @var bool
-     */
-    private $enabled = true;
+    private bool $enabled = true;
 
     public function setEnabled(bool $bool): void
     {
         $this->enabled = $bool;
     }
 
-    protected function doEnterNode(Node $node, Environment $env): Node
+    public function enterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -46,7 +43,7 @@ final class RemovingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    protected function doLeaveNode(Node $node, Environment $env): Node
+    public function leaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }


### PR DESCRIPTION
Fix deprecation
```
1x: The "Translation\Bundle\Twig\Visitor\NormalizingNodeVisitor" class extends "Twig\NodeVisitor\AbstractNodeVisitor" that is deprecated since Twig 3.9 (to be removed in 4.0).
|     1x in CheckMissingCommandTest::testReportsMissingTranslations from Translation\Bundle\Tests\Functional\Command
| 
|   1x: The "Translation\Bundle\Twig\Visitor\RemovingNodeVisitor" class extends "Twig\NodeVisitor\AbstractNodeVisitor" that is deprecated since Twig 3.9 (to be removed in 4.0).
|     1x in CheckMissingCommandTest::testReportsMissingTranslations from Translation\Bundle\Tests\Functional\Command
| 
|   1x: The "Translation\Bundle\Twig\Visitor\DefaultApplyingNodeVisitor" class extends "Twig\NodeVisitor\AbstractNodeVisitor" that is deprecated since Twig 3.9 (to be removed in 4.0).
|     1x in CheckMissingCommandTest::testReportsMissingTranslations from Translation\Bundle\Tests\Functional\Command
```