### PR TITLE
feat: use ubuntu-24.04 for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   build:
     name: Test
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-24.04
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpstan:
     name: PHPStan
-    runs-on: Ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
   php-cs-fixer:
     name: PHP-CS-Fixer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: PHP-CS-Fixer
@@ -51,7 +51,7 @@ jobs:
 
   psalm:
     name: Psalm
-    runs-on: Ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
fix github actions see #520
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```