### PR TITLE
Guard against missing twig_callable attribute

### DIFF
--- a/Legacy/LegacyHelper.php
+++ b/Legacy/LegacyHelper.php
@@ -34,7 +34,7 @@ class LegacyHelper
     /**
      * @param array[string $id, string $parent, ?bool $isPublic] $legacyServices
      */
-    public static function registerDeprecatedServices(ServicesConfigurator $servicesConfigurator, array $legacyServices)
+    public static function registerDeprecatedServices(ServicesConfigurator $servicesConfigurator, array $legacyServices): void
     {
         foreach ($legacyServices as $legacyService) {
             $id = $legacyService[0];

--- a/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
+++ b/Tests/Unit/Translator/EditInPlaceTranslatorTest.php
@@ -25,7 +25,7 @@ use Translation\Bundle\Translator\TranslatorInterface;
  */
 final class EditInPlaceTranslatorTest extends TestCase
 {
-    public function testWithNotLocaleAwareTranslator()
+    public function testWithNotLocaleAwareTranslator(): void
     {
         if (!interface_exists(NewTranslatorInterface::class)) {
             $this->markTestSkipped('Relevant only when NewTranslatorInterface is available.');

--- a/Tests/Unit/Translator/FallbackTranslatorTest.php
+++ b/Tests/Unit/Translator/FallbackTranslatorTest.php
@@ -24,7 +24,7 @@ use Translation\Translator\TranslatorService;
  */
 final class FallbackTranslatorTest extends TestCase
 {
-    public function testWithNotLocaleAwareTranslator()
+    public function testWithNotLocaleAwareTranslator(): void
     {
         if (!interface_exists(NewTranslatorInterface::class)) {
             $this->markTestSkipped('Relevant only when NewTranslatorInterface is available.');

--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -45,18 +45,19 @@ final class DefaultApplyingNodeVisitor implements NodeVisitorInterface
             return $node;
         }
 
-        if (!($node instanceof FilterExpression && 'desc' === $node->getAttribute('twig_callable')->getName())) {
+        if (!($node instanceof FilterExpression && $node->hasAttribute('twig_callable') && 'desc' === $node->getAttribute('twig_callable')->getName())) {
             return $node;
         }
 
         $transNode = $node->getNode('node');
         while ($transNode instanceof FilterExpression
+                   && $transNode->hasAttribute('twig_callable')
                    && 'trans' !== $transNode->getAttribute('twig_callable')->getName()
                    && 'transchoice' !== $transNode->getAttribute('twig_callable')->getName()) {
             $transNode = $transNode->getNode('node');
         }
 
-        if (!$transNode instanceof FilterExpression) {
+        if (!$transNode instanceof FilterExpression || !$transNode->hasAttribute('twig_callable')) {
             throw new \RuntimeException('The "desc" filter must be applied after a "trans", or "transchoice" filter.');
         }
 

--- a/Twig/Visitor/DefaultApplyingNodeVisitor.php
+++ b/Twig/Visitor/DefaultApplyingNodeVisitor.php
@@ -57,8 +57,12 @@ final class DefaultApplyingNodeVisitor implements NodeVisitorInterface
             $transNode = $transNode->getNode('node');
         }
 
-        if (!$transNode instanceof FilterExpression || !$transNode->hasAttribute('twig_callable')) {
+        if (!$transNode instanceof FilterExpression) {
             throw new \RuntimeException('The "desc" filter must be applied after a "trans", or "transchoice" filter.');
+        }
+
+        if (!$transNode->hasAttribute('twig_callable')) {
+            return $node;
         }
 
         $wrappingNode = $node->getNode('node');

--- a/Twig/Visitor/RemovingNodeVisitor.php
+++ b/Twig/Visitor/RemovingNodeVisitor.php
@@ -32,7 +32,7 @@ final class RemovingNodeVisitor implements NodeVisitorInterface
 
     public function enterNode(Node $node, Environment $env): Node
     {
-        if ($this->enabled && $node instanceof FilterExpression) {
+        if ($this->enabled && $node instanceof FilterExpression && $node->hasAttribute('twig_callable')) {
             $name = $node->getAttribute('twig_callable')->getName();
 
             if ('desc' === $name || 'meaning' === $name) {


### PR DESCRIPTION
PR added with a minimal compatibility fix for custom FilterExpression nodes that do not expose the "twig_callable" attribute.

The changes only add guard checks before accessing the attribute, without changing the existing behavior for regular Twig filter expressions.